### PR TITLE
chore: Dependabot PRs target dev instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Eleventy + CI tools (html-validate, pa11y, Lighthouse, http-server, wait-on).
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -29,6 +30,7 @@ updates:
   # GitHub Actions pinned in .github/workflows/ci.yml.
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
Adds \`target-branch: \"dev\"\` to both Dependabot ecosystems in \`.github/dependabot.yml\` (npm + github-actions).

## Why
The task-branch → dev → main workflow in \`core_docs/development-rules.md\` requires nothing to land on \`main\` directly. Dependabot's default was targeting \`main\`, which created 5 flow-violating PRs earlier today (now rebased onto dev).

## Test plan
- [ ] Next scheduled Dependabot run opens PRs against \`dev\`, not \`main\`.