### PR TITLE
Fix, lychee resolves root-relative links with --base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Broken-link check (lychee)
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --offline _site
+          # --base tells lychee how to resolve root-relative paths (/foo → _site/foo).
+          # --offline skips external URL fetches (keeps CI deterministic).
+          args: --no-progress --offline --base _site _site
           fail: false
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary
Adds \`--base _site\` to the lychee link-check step in \`.github/workflows/ci.yml\`.

## Why
In offline mode lychee had no way to map \`/foo\` to \`_site/foo\`, so every root-relative \`href\`/\`src\` (192 total across 7 pages) was flagged as a broken link. The step runs with \`fail: false\` so CI was passing, but the logs were full of noise.

After this change lychee resolves \`/img/logos/logo.svg\` → \`_site/img/logos/logo.svg\` correctly.

## Test plan
- [ ] Next CI run on this branch shows 0 or near-0 broken-link errors in the lychee step.