### PR TITLE
Wire contact form to submitContactForm CF (landing side of #2)

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -2,7 +2,7 @@
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
   "cssVersion": "260417_1",
-  "jsVersion": "260417_1",
+  "jsVersion": "260417_2",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",
   "ogImage": "https://dipnot.app/android-chrome-512x512.png",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -58,5 +58,8 @@
   <!-- Scripts -->
   <script src="/js/main.js?v={{ site.jsVersion }}"></script>
   <script src="/js/newsletter.js?v={{ site.jsVersion }}"></script>
+  {%- if hasContactForm %}
+  <script src="/js/contact.js?v={{ site.jsVersion }}"></script>
+  {%- endif %}
 </body>
 </html>

--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -99,6 +99,11 @@ og:
           <br>
           <span>Mobil uygulamadaki kullanım istatistiklerini analiz etmek, kullanıcı davranışlarını anlamak ve deneyimi iyileştirmek amacıyla. Toplanan veriler arasında cihaz tanımlayıcıları, oturum süreleri, ekran görüntülemeleri ve uygulama içi etkileşim olayları yer alır. Bu verileri pazarlama veya üçüncü taraf reklam ağlarıyla paylaşmıyoruz.</span>
         </li>
+        <li>
+          <strong>Firebase Cloud Functions — İletişim Formu (Google LLC, us-central1 – ABD):</strong>
+          <br>
+          <span>dipnot.app web sitesindeki iletişim formu aracılığıyla gönderdiğiniz ad, e-posta, konu ve mesaj bilgileri Firebase Cloud Functions üzerinden işlenir ve yönetim paneli tarafından okunmak üzere Firestore'da (<code>contactSubmissions</code> koleksiyonu) saklanır. Kötüye kullanım incelemesi ve spam önleme amacıyla IP adresiniz ve tarayıcı bilgileriniz (user-agent) otomatik olarak kaydedilir. Bu aktarım KVKK'nın 9. maddesi kapsamında açık rızanıza dayanılarak gerçekleştirilir.</span>
+        </li>
       </ul>
       <p>Yurt dışına aktarım söz konusu olduğunda, KVKK'nın 9. maddesi uyarınca yeterli korumanın bulunduğu ülkelere (örneğin, AB ülkeleri) veya veri sorumlusunun yeterli korumayı yazılı olarak taahhüt ettiği hizmet sağlayıcılara aktarım yapılmaktadır. ABD'de yerleşik sağlayıcılara (Expo dahil) yapılan aktarımlar, açık rızanız alınarak veya KVKK md. 9 uyarınca gerekli güvenceler sağlanarak yapılır.</p>
 

--- a/index.html
+++ b/index.html
@@ -8,9 +8,10 @@ og:
   locale: tr_TR
   url: "https://dipnot.app/"
   description: "Dipnot, dalış ve su altı dünyasına ilgi duyanlar için hazırlanmış makale odaklı bir mobil içerik platformudur."
+hasContactForm: true
 ---
 <!-- HERO BANNER -->
-<section class="hero is-fullheight-with-navbar has-background-hero mt-6">
+<section class="hero is-fullheight-with-navbar has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column is-align-content-center">
@@ -285,9 +286,14 @@ og:
 
             <div class="card-content">
 
-              <!-- TODO: form is not working -->
               <!-- Contact Form -->
-              <form>
+              <form id="contact-form">
+
+                <!-- Honeypot (spam trap — bots fill this, humans don't see it) -->
+                <div class="is-hidden" aria-hidden="true">
+                  <label for="contact-website">Website</label>
+                  <input id="contact-website" name="website" type="text" tabindex="-1" autocomplete="off">
+                </div>
 
                 <!-- Name -->
                 <div class="field">
@@ -354,6 +360,9 @@ og:
                     </button>
                   </div>
                 </div>
+
+                <!-- Feedback (success/error) -->
+                <p id="contact-feedback" class="help mt-3" role="status" aria-live="polite"></p>
 
               </form>
               <!-- /Contact Form -->

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,56 @@
+const form = document.getElementById("contact-form");
+const feedback = document.getElementById("contact-feedback");
+const button = form.querySelector("button[type=submit]");
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+
+  feedback.textContent = "";
+  feedback.className = "help mt-3";
+  button.classList.add("is-loading");
+  button.disabled = true;
+
+  try {
+    const formData = new FormData(form);
+
+    // Honeypot: if filled, pretend success and skip the network call.
+    if (formData.get("website")) {
+      feedback.textContent = "Mesajınız iletildi.";
+      feedback.classList.add("is-success");
+      form.reset();
+      return;
+    }
+
+    const payload = {
+      name: formData.get("name"),
+      email: formData.get("email"),
+      subject: formData.get("subject"),
+      message: formData.get("message"),
+    };
+
+    const res = await fetch(
+      "https://us-central1-dipnotapp.cloudfunctions.net/submitContactForm",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }
+    );
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.error || "Bir hata oluştu");
+    }
+
+    feedback.textContent = data.message || "Mesajınız iletildi.";
+    feedback.classList.add("is-success");
+    form.reset();
+  } catch (err) {
+    feedback.textContent = err.message;
+    feedback.classList.add("is-danger");
+  } finally {
+    button.classList.remove("is-loading");
+    button.disabled = false;
+  }
+});

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -103,6 +103,11 @@ og:
           <br>
           <span>Used to analyse in-app usage statistics, understand user behaviour, and improve the experience. Data collected includes device identifiers, session durations, screen views, and in-app interaction events. We do not share this data with marketing or third-party ad networks.</span>
         </li>
+        <li>
+          <strong>Firebase Cloud Functions — Contact form (Google LLC, us-central1 – USA):</strong>
+          <br>
+          <span>The name, email, subject, and message you submit through the contact form on dipnot.app are processed by Firebase Cloud Functions and stored in Firestore (<code>contactSubmissions</code> collection) to be read by the admin panel. Your IP address and browser information (user-agent) are automatically recorded for abuse investigation and spam prevention. This transfer is carried out based on your explicit consent under KVKK article 9.</span>
+        </li>
       </ul>
       <p>Where cross-border transfer is involved, transfers are made under KVKK article 9 to countries with adequate protection (e.g. EU countries) or to service providers that have committed in writing to provide adequate protection. Transfers to US-based providers (including Expo) are carried out with your explicit consent or under the safeguards required by KVKK article 9.</p>
 


### PR DESCRIPTION
## Summary
- Wires the previously-stubbed contact form in [index.html](index.html) to a new Firebase Cloud Function endpoint `submitContactForm` (us-central1), mirroring the existing newsletter flow.
- Adds `id`, honeypot, and `aria-live` feedback element to the form markup.
- Adds [js/contact.js](js/contact.js) with honeypot short-circuit + Bulma `is-success`/`is-danger` feedback states.
- Loads `contact.js` conditionally — only on pages declaring `hasContactForm: true` in frontmatter (currently only `index.html`).
- Bumps `jsVersion` to `260417_2` for cache-bust.
- Discloses contact-form IP / user-agent capture in the KVKK policy (both `gizlilik-politikasi.html` and `privacy-policy.html`), mirrored from [../core_docs/data-processors.md](../core_docs/data-processors.md) where the new processor entry was just added.

## Cross-repo work (not in this PR)
- **`FirebaseFunctions`**: deploy `submitContactForm` — writes to Firestore `contactSubmissions/{autoId}` with fields `name`, `email`, `subject`, `message`, `createdAt` (server ts), `status: "new"`, `ipAddress`, `userAgent`. Honeypot silent-200. Per-IP rate limit. CORS allow `https://dipnot.app`.
- **`admin_dipnot_app`**: add "İletişim Mesajları" list view reading `contactSubmissions` ordered by `createdAt desc`, with status toggle (new → read → archived).

Backend, DB field names, and code comments are **English only**; UI copy stays Turkish.

## Test plan
- [ ] Merge the matching `submitContactForm` deploy in `FirebaseFunctions`
- [ ] `npm run serve` → open http://localhost:8080 → submit valid form → confirm success state + network POST to CF
- [ ] Submit again, fill hidden `#contact-website` via devtools → confirm silent success, no CF call
- [ ] Submit with CF returning 4xx/5xx → confirm `is-danger` rendering
- [ ] Verify `contact.js` does **not** load on [gizlilik-politikasi.html](gizlilik-politikasi.html), [kullanim-kosullari.html](kullanim-kosullari.html), etc.
- [ ] `npm run check:html` still passes (or no new errors beyond the 11 known)
- [ ] `npm run check:links` still passes

Closes #2 once the Cloud Function lands and test plan passes.