### PR TITLE
Wire Facebook footer link to real page (closes #6)

### DIFF
--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -19,43 +19,49 @@
 
         <p>Dalış dünyasına dair paylaşımlar için bizi sosyal ağlarda takip edin:</p>
         <div class="buttons are-large mt-5">
+
+          <!-- Instagram social media link -->
           <a href="https://www.instagram.com/dipnot.app" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="Instagram" aria-label="Dipnot'u Instagram'da takip et">
             <span class="icon is-small">
               <i class="fa-brands fa-instagram"></i>
             </span>
           </a>
 
-          <!-- TODO: add social media link -->
-          <a href="https://www.instagram.com/dipnot.app" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="Facebook" aria-label="Dipnot'u Facebook'ta takip et">
+          <!-- Facebook social media link -->
+          <a href="https://www.facebook.com/profile.php?id=61568027754102" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="Facebook" aria-label="Dipnot'u Facebook'ta takip et">
             <span class="icon is-small">
               <i class="fa-brands fa-facebook"></i>
             </span>
           </a>
 
-          <!-- TODO: add social media link -->
+          <!-- TODO: add Twitter social media link -->
           <a href="https://www.instagram.com/dipnot.app" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="X" aria-label="Dipnot'u X'te takip et">
             <span class="icon is-small">
               <i class="fa-brands fa-x-twitter"></i>
             </span>
           </a>
 
+          <!-- Linkedin social media link -->
           <a href="https://www.linkedin.com/company/dipnotapp" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="Linkedin" aria-label="Dipnot'u LinkedIn'de takip et">
             <span class="icon is-small">
               <i class="fa-brands fa-linkedin"></i>
             </span>
           </a>
 
+          <!-- Theorg social media link -->
           <a href="https://theorg.com/org/dipnot-1" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="The Org" aria-label="Dipnot'u The Org'da görüntüle">
             <span class="icon is-small">
               <i class="fa-solid fa-sitemap"></i>
             </span>
           </a>
 
+          <!-- Stackshare social media link -->
           <a href="https://stackshare.io/nevcanuludas/dipnot-app" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="Stack Share" aria-label="Dipnot'un teknoloji yığınını Stack Share'de görüntüle">
             <span class="icon is-small">
               <i class="fa-solid fa-share-nodes"></i>
             </span>
           </a>
+
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replaces the Instagram placeholder URL on the Facebook footer anchor with the real Dipnot Facebook page (facebook.com/profile.php?id=61568027754102).
- Removes the `<!-- TODO: add social media link -->` comment that paired with it.
- Renames the surviving placeholder TODO to specify it's for X/Twitter (tracked separately in #7, still blocked on the account being set up).
- Adds section comments around each social anchor for readability.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Footer Facebook anchor opens the real Dipnot Facebook page in a new tab
- [ ] `rel="noopener noreferrer"` still present
- [ ] aria-label unchanged

Closes #6