### PR TITLE
Load Inter font and override Bulma default stack

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
-  "cssVersion": "260417_1",
+  "cssVersion": "260419_1",
   "jsVersion": "260417_2",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -33,6 +33,10 @@
   {%- endif %}
 
   <title>{{ title }}</title>
+  <!-- Inter via Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&subset=latin-ext&display=swap">
   <!-- Bulma CDN -->
   <link rel="stylesheet" href="{{ site.cdn.bulma.href }}" integrity="{{ site.cdn.bulma.integrity }}" crossorigin="anonymous">
   <!-- Font Awesome CDN -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -3,6 +3,12 @@
   --color-primary: #04d1b2;
 }
 
+body,
+h1, h2, h3, h4, h5, h6,
+.title, .subtitle {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+}
+
 .navbar.is-fixed-top {
   box-shadow: 0 0 10px black;
 }


### PR DESCRIPTION
## Summary
- Load Inter (400 / 500 / 600 / 700, latin + latin-ext subsets) via Google Fonts CDN in the shared [`base.njk`](_includes/layouts/base.njk) head with `preconnect` hints for `fonts.googleapis.com` and `fonts.gstatic.com`.
- Override Bulma's default font stack in [`css/styles.css`](css/styles.css) on `body`, `h1`–`h6`, `.title`, and `.subtitle` so the swap is site-wide without per-component changes. System fallbacks preserved.
- Bump `cssVersion` to `260419_1` to cache-bust the override.

## Scope note
Partial fulfillment of the open Inter-adoption ask in core_docs. **Font-only** per user direction — the typography-token helper classes (`.text-caption` / `.text-small` / `.text-lead`) and the `CHANGELOG.md` entry called for in the ask are deferred to a follow-up. The ask stays open in `core_docs/communication/to-landing.md`.

## Known trade-off — no SRI on Google Fonts
The repo's security baseline pins every CDN stylesheet with `integrity="sha384-..."`. Google Fonts' CSS endpoint returns different content per User-Agent, which makes SRI pinning unreliable. Options if we want the guarantee:
- Self-host Inter via `@fontsource/inter` (build-time dep, works with Eleventy's passthrough).
- Pin to a static mirror (jsdelivr / unpkg) with a hash.

Flagging for later — not blocking.

## Test plan
- [ ] `npm run serve` — Inter renders on index, brand-book, privacy policy, terms, 404.
- [ ] DevTools → Network tab: `fonts.googleapis.com/css2?family=Inter...` 200 on first load, cached on subsequent.
- [ ] No FOUT on cold load (preconnect + `display=swap` behavior acceptable).
- [ ] CI passes on the branch (html-validate / pa11y / Lighthouse / lychee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)