### PR TITLE
Swap brand-book logo tiles to composed SVG variants

### DIFF
--- a/brand-book.html
+++ b/brand-book.html
@@ -20,18 +20,6 @@ og:
 </section>
 
 <!-- MAIN PAGE -->
-<style>
-  .filter-algiers-blue {
-    filter: invert(46%) sepia(60%) saturate(430%) hue-rotate(143deg) brightness(88%) contrast(90%);
-  }
-  .filter-sky-captain {
-    filter: invert(6%) sepia(51%) saturate(641%) hue-rotate(174deg) brightness(98%) contrast(91%);
-  }
-  .filter-white {
-    filter: brightness(0) invert(1);
-  }
-</style>
-
 <main class="container py-6">
   <a href="https://app.gingersauce.co/my/view-new-v3/72228" target="_blank" rel="noopener noreferrer">Dipnot Brand Book by Gingersauce</a>
 
@@ -43,6 +31,7 @@ og:
     </div>
 
     <div class="columns has-background-white">
+
       <div class="column">
         <div class="box has-background-white">
           <figure class="has-text-centered p-6">
@@ -54,26 +43,27 @@ og:
       <div class="column">
         <div class="box has-background-white">
           <figure class="has-text-centered p-6">
-            <img src="/img/logos/logo.svg" alt="Logo" width="200" class="filter-sky-captain">
+            <img src="/img/logos/logo-gold.svg" class="has-text-centered" alt="Logo" width="200">
           </figure>
         </div>
       </div>
 
       <div class="column">
-        <div class="box" style="background-color: #348698;">
-          <figure class="has-text-centered p-6">
-            <img src="/img/logos/logo.svg" alt="Logo" width="200" class="filter-white">
+        <div class="box" style="background-color: #338596;">
+          <figure class="has-text-centered">
+            <img src="/img/logos/logo-white-on-teal.svg" class="has-text-centered" alt="Logo" width="280">
           </figure>
         </div>
       </div>
 
       <div class="column">
         <div class="box" style="background-color: #131B26;">
-          <figure class="has-text-centered p-6">
-            <img src="/img/logos/logo.svg" alt="Logo" width="200" class="filter-white">
+          <figure class="has-text-centered">
+            <img src="/img/logos/logo-white-on-sky-captain.svg" class="has-text-centered" alt="Logo" width="280">
           </figure>
         </div>
       </div>
+
     </div>
   </section>
 
@@ -125,6 +115,7 @@ og:
     </div>
 
     <div class="columns">
+
       <div class="column">
         <div class="box has-text-centered" style="background-color: #131B26;">
           Primary Font
@@ -135,15 +126,6 @@ og:
         </div>
       </div>
 
-      <div class="column">
-        <div class="box has-text-centered" style="background-color: #2E162C;">
-          Secondary Font
-          <br>
-          Poppins
-          <br>
-          Aa
-        </div>
-      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Replace the `.filter-*` CSS hacks (which recolored a single teal `logo.svg` at render time) with proper per-variant SVGs from [`img/logos/`](img/logos/) — now that the full variant set is merged:
  - Tile 2 → `logo-gold.svg` (new gold showcase).
  - Tile 3 → `logo-white-on-teal.svg` on a `#338596` teal box.
  - Tile 4 → `logo-white-on-sky-captain.svg` on a `#131B26` Sky Captain box.
- Tile backgrounds use the ratified hex values (`rgb(51,133,150)` and `rgb(19,27,38)`) so the div bg seams cleanly into the SVG's baked-in background.
- Drop the now-unused "Secondary Font Poppins" column from the typography section — Inter is the one ratified family.

## Explicitly out of scope
Still stale, tracked for a separate rewrite:
- "Algiers Blue `#348698`" swatch in the Colors section — should be "Dipnot Teal `#338596`".
- Empty **Rules**, **Misuse**, and **Brand Archetype** sections.
- Overall page structure / voice.

## Test plan
- [ ] Visual check on `/brand-book.html` — each tile renders the right variant; no 1-pixel color seams between the div bg and the SVG bg.
- [ ] CI passes (html-validate / pa11y / Lighthouse / lychee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)