### PR TITLE
Convert Turkish UI copy to sentence case

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
 lang: tr
-title: "Sayfa Bulunamadı | Dipnot App"
+title: "Sayfa bulunamadı | Dipnot App"
 description: "Sayfa bulunamadı — Dipnot App."
 keywords: "dalış, scuba diving, su altı, dipnot app"
 robots: "noindex"
@@ -13,7 +13,7 @@ permalink: "/404.html"
   <div class="hero-body">
     <div class="columns">
       <div class="column is-align-content-center">
-        <p class="title is-size-1 has-text-white has-text-centered mb-5"><span class="has-text-primary" style="font-size: 12rem;">404</span> <span style="white-space: nowrap;">Sayfa Bulunamadı</span></p>
+        <p class="title is-size-1 has-text-white has-text-centered mb-5"><span class="has-text-primary" style="font-size: 12rem;">404</span> <span style="white-space: nowrap;">Sayfa bulunamadı</span></p>
         <p class="subtitle has-text-white has-text-centered">Üzgünüz, aradığınız sayfa bulunamadı.</p>
         <div class="buttons are-large mt-6 is-flex is-justify-content-center mb-6">
           <a href="/" class="button is-light is-outlined">

--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -67,12 +67,12 @@
 
       <div class="column mb-6">
         <aside class="menu" aria-label="Site haritası">
-          <p class="menu-label">Site Haritası</p>
+          <p class="menu-label">Site haritası</p>
           <ul class="menu-list">
-            <li><a href="/" style="background-color: transparent;">Ana Sayfa</a></li>
-            <li><a href="/#about" style="background-color: transparent;">Dipnot Nedir?</a></li>
+            <li><a href="/" style="background-color: transparent;">Ana sayfa</a></li>
+            <li><a href="/#about" style="background-color: transparent;">Dipnot nedir?</a></li>
             <li><a href="/#features" style="background-color: transparent;">Özellikler</a></li>
-            <li><a href="/#how-it-works" style="background-color: transparent;">Nasıl Çalışır?</a></li>
+            <li><a href="/#how-it-works" style="background-color: transparent;">Nasıl çalışır?</a></li>
             <li><a href="/#faq" style="background-color: transparent;">S.S.S.</a></li>
             <li><a href="/#contact" style="background-color: transparent;">İletişim</a></li>
           </ul>
@@ -82,7 +82,7 @@
       <!-- Newsletter -->
       <div class="column mb-6">
         <aside class="menu pr-5" aria-label="Bülten aboneliği">
-          <p class="menu-label">Bülten Aboneliği</p>
+          <p class="menu-label">Bülten aboneliği</p>
 
           <form id="newsletter-form">
             <div class="field">
@@ -102,7 +102,7 @@
 
             <div class="field">
               <button class="button is-primary is-fullwidth" type="submit">
-                Abone Ol
+                Abone ol
               </button>
             </div>
 
@@ -132,7 +132,7 @@
 
           <address class="mb-4">1. Kısım Mah. Vali Recep Yazıcıoğlu Cad. Doğa Parkı Evleri BC Blok No:15/13 Bahçeşehir, İstanbul, Türkiye.</address>
 
-          <p class="has-text-weight-semibold mt-4">Genel İletişim:</p>
+          <p class="has-text-weight-semibold mt-4">Genel iletişim:</p>
           <p>
             <span class="icon mr-2">
               <i class="fa-solid fa-envelope"></i>
@@ -140,7 +140,7 @@
             <a href="mailto:info@dipnot.app">info@dipnot.app</a>
           </p>
 
-          <p class="has-text-weight-semibold mt-4">Teknik Destek:</p>
+          <p class="has-text-weight-semibold mt-4">Teknik destek:</p>
           <p>
             <span class="icon mr-2">
               <i class="fa-solid fa-life-ring"></i>
@@ -156,7 +156,7 @@
 
     <div class="columns mt-6">
       <div class="column has-text-centered">
-        Copyright &copy; 2025&ndash;2026 <span class="mx-4">|</span> <a href="/gizlilik-politikasi.html">Gizlilik Politikası</a> <span class="mx-4">|</span> <a href="/kullanim-kosullari.html">Kullanım Koşulları</a>
+        Copyright &copy; 2025&ndash;2026 <span class="mx-4">|</span> <a href="/gizlilik-politikasi.html">Gizlilik politikası</a> <span class="mx-4">|</span> <a href="/kullanim-kosullari.html">Kullanım koşulları</a>
         <br>
         Website <a href="https://vacstudio.com/" target="_blank" rel="noopener noreferrer">V.A.C. Studio</a> tarafından geliştirilmiştir.
       </div>

--- a/_includes/partials/nav.njk
+++ b/_includes/partials/nav.njk
@@ -13,7 +13,7 @@
             id="theme-toggle-mobile"
             type="button"
             class="button is-text"
-            aria-label="Tema Değiştir"
+            aria-label="Tema değiştir"
             style="text-decoration: none;"
           >
             <span class="icon">
@@ -33,10 +33,10 @@
 
     <div id="navbar" class="navbar-menu">
       <div class="navbar-start">
-        <a class="navbar-item" href="/">Ana Sayfa</a>
-        <a class="navbar-item" href="/#about">Dipnot Nedir?</a>
+        <a class="navbar-item" href="/">Ana sayfa</a>
+        <a class="navbar-item" href="/#about">Dipnot nedir?</a>
         <a class="navbar-item" href="/#features">Özellikler</a>
-        <a class="navbar-item" href="/#how-it-works">Nasıl Çalışır?</a>
+        <a class="navbar-item" href="/#how-it-works">Nasıl çalışır?</a>
         <a class="navbar-item" href="/#faq">S.S.S.</a>
         <a class="navbar-item" href="/#contact">İletişim</a>
       </div>
@@ -47,7 +47,7 @@
             id="theme-toggle"
             type="button"
             class="button is-text"
-            aria-label="Tema Değiştir"
+            aria-label="Tema değiştir"
             style="text-decoration: none;"
           >
             <span class="icon">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ hasContactForm: true
   <div class="hero-body">
     <div class="columns">
       <div class="column is-align-content-center">
-        <h1 class="title is-size-1 has-text-white mb-5">Su Altını <span class="has-text-primary">Okumaya</span> <span style="white-space: nowrap;">Hazır mısınız?</span></h1>
+        <h1 class="title is-size-1 has-text-white mb-5">Su altını <span class="has-text-primary">okumaya</span> <span style="white-space: nowrap;">hazır mısınız?</span></h1>
         <p class="subtitle has-text-white">Etkinliklerden teknolojiye, güvenlikten ekipmanlara dalış dünyasını derinlemesine ele alan içerikler...</p>
         <div class="buttons are-large mt-6 is-flex is-justify-content-center mb-6">
           <button type="button" class="button is-light is-outlined is-rounded">
@@ -54,7 +54,7 @@ hasContactForm: true
 
           <div class="column is-7 is-flex is-justify-content-center">
             <div class="is-align-content-center px-6 py-5" style="max-width: 600px;">
-              <h2 class="title is-2 mb-4"><span class="has-text-primary">Dipnot</span> Nedir?</h2>
+              <h2 class="title is-2 mb-4"><span class="has-text-primary">Dipnot</span> nedir?</h2>
               <p class="mt-3">Dipnot, dalış ve su altı dünyasına ilgi duyan herkes için hazırlanmış bağımsız bir içerik platformudur. Uygulama içinde; dalış kültürü, güvenlik, ekipman, çevre, tarih ve güncel konular üzerine özenle yazılmış makalelere ulaşabilirsiniz.</p>
               <p class="mt-3">Dipnot, hızlı tüketilen içerikler yerine kalıcı ve referans alınabilir bilgiler sunmayı amaçlar. Yeni başlayanlardan deneyimli dalıcılara kadar herkes için, okunabilir, sade ve güvenilir bir kaynak oluşturur.</p>
             </div>
@@ -77,7 +77,7 @@ hasContactForm: true
           <span class="icon is-large mb-4">
             <i class="fa-solid fa-feather-pointed fa-3x"></i>
           </span>
-          <h3 class="title is-5">Küratörlü İçerikler</h3>
+          <h3 class="title is-5">Küratörlü içerikler</h3>
           <p>Deneyimli dalıcılar tarafından hazırlanmış nitelikli yazılar.</p>
         </div>
       </div>
@@ -97,7 +97,7 @@ hasContactForm: true
           <span class="icon is-large mb-4">
             <i class="fa-solid fa-sliders fa-3x"></i>
           </span>
-          <h3 class="title is-5">Kişisel Deneyim</h3>
+          <h3 class="title is-5">Kişisel deneyim</h3>
           <p>Profiline göre şekillenen okuma akışı.</p>
         </div>
       </div>
@@ -107,7 +107,7 @@ hasContactForm: true
           <span class="icon is-large mb-4">
             <i class="fa-solid fa-minimize fa-3x"></i>
           </span>
-          <h3 class="title is-5">Sade Arayüz</h3>
+          <h3 class="title is-5">Sade arayüz</h3>
           <p>Dikkat dağıtmayan, odaklı tasarım.</p>
         </div>
       </div>
@@ -118,7 +118,7 @@ hasContactForm: true
   <section id="how-it-works" class="section">
     <div class="columns is-multiline">
       <div class="column is-12 has-text-centered">
-        <h2 class="title is-2 mb-6">Nasıl Çalışır?</h2>
+        <h2 class="title is-2 mb-6">Nasıl çalışır?</h2>
       </div>
 
       <div class="column">
@@ -129,7 +129,7 @@ hasContactForm: true
                 <img src="/img/apw-Icon2.png" alt="Ücretsiz indir">
               </figure>
 
-              <h3 class="is-size-3 mt-4">Ücretsiz İndir</h3>
+              <h3 class="is-size-3 mt-4">Ücretsiz indir</h3>
             </div>
           </div>
 
@@ -147,7 +147,7 @@ hasContactForm: true
                 <img src="/img/apw-Icon1.png" alt="Profil oluştur">
               </figure>
 
-              <h3 class="is-size-3 mt-4">Profil Oluştur</h3>
+              <h3 class="is-size-3 mt-4">Profil oluştur</h3>
             </div>
           </div>
 
@@ -165,7 +165,7 @@ hasContactForm: true
                 <img src="/img/apw-Icon3.png" alt="İçerikleri keşfet">
               </figure>
 
-              <h3 class="is-size-3 mt-4">İçerikleri Keşfet</h3>
+              <h3 class="is-size-3 mt-4">İçerikleri keşfet</h3>
             </div>
           </div>
 
@@ -190,7 +190,7 @@ hasContactForm: true
       </div>
 
       <div class="column is-7">
-        <h2 class="title is-2 mb-6">Sıkça Sorulan Sorular</h2>
+        <h2 class="title is-2 mb-6">Sıkça sorulan sorular</h2>
 
         <div class="card">
           <header class="card-header is-clickable">
@@ -297,7 +297,7 @@ hasContactForm: true
 
                 <!-- Name -->
                 <div class="field">
-                  <label class="label" for="contact-name">Ad Soyad</label>
+                  <label class="label" for="contact-name">Ad soyad</label>
                   <div class="control has-icons-left">
                     <input id="contact-name" name="name" class="input" type="text" placeholder="Adınız ve soyadınız" required>
                     <span class="icon is-small is-left">
@@ -323,10 +323,10 @@ hasContactForm: true
                   <div class="control">
                     <div class="select is-fullwidth">
                       <select id="contact-subject" name="subject">
-                        <option value="general">Genel Bilgi</option>
-                        <option value="support">Teknik Destek</option>
-                        <option value="partnership">İş Birliği</option>
-                        <option value="feedback">Geri Bildirim</option>
+                        <option value="general">Genel bilgi</option>
+                        <option value="support">Teknik destek</option>
+                        <option value="partnership">İş birliği</option>
+                        <option value="feedback">Geri bildirim</option>
                       </select>
                     </div>
                   </div>
@@ -346,7 +346,7 @@ hasContactForm: true
                     <label class="checkbox">
                       <input type="checkbox" required>
                       <span>
-                        <a href="/kullanim-kosullari.html" target="_blank" rel="noopener noreferrer">Kullanım Koşulları</a> ve <a href="/gizlilik-politikasi.html" target="_blank" rel="noopener noreferrer">Gizlilik Politikası</a> bilgilendirme metinlerini okudum ve kabul ediyorum.
+                        <a href="/kullanim-kosullari.html" target="_blank" rel="noopener noreferrer">Kullanım koşulları</a> ve <a href="/gizlilik-politikasi.html" target="_blank" rel="noopener noreferrer">Gizlilik politikası</a> bilgilendirme metinlerini okudum ve kabul ediyorum.
                       </span>
                     </label>
                   </div>


### PR DESCRIPTION
## Summary

Applies the Turkish sentence-case rule from `core_docs/product-design/typography.md` to UI copy across the nav, footer, index, and 404 — 32 insertions / 32 deletions, pure copy edits (no structural changes).

- **`_includes/partials/nav.njk`** — menu items (`Ana sayfa`, `Dipnot nedir?`, `Nasıl çalışır?`), theme-toggle `aria-label`.
- **`_includes/partials/footer.njk`** — menu labels (`Site haritası`, `Bülten aboneliği`), sitemap links, contact-section heads (`Genel iletişim`, `Teknik destek`), newsletter button (`Abone ol`), legal-doc links (`Gizlilik politikası`, `Kullanım koşulları`).
- **[`index.html`](index.html)** — hero H1 (`Su altını okumaya hazır mısınız?`), section H2s (`Dipnot nedir?`, `Nasıl çalışır?`, `Sıkça sorulan sorular`), feature card titles, how-it-works step titles, contact form label (`Ad soyad`) and select options, terms-checkbox link text.
- **[`404.html`](404.html)** — frontmatter `<title>` and hero heading.

Proper nouns (**Dipnot**, **Google Play**, **App Store**, **V.A.C. Studio**) and acronyms (**KVKK**, **SSS**) stay capitalized. Single-word headings (`Özellikler`, `İletişim`, `Kategoriler`) are unchanged — already correct.

## Smart quotes

`core_docs/product-design/typography.md` currently prescribes Turkish guillemets (`«…»`) for long-form editorial, but real-world Turkish usage is straight ASCII `"..."` everywhere. Every Turkish file in this repo already uses ASCII quotes — nothing to convert. Worth flagging back to core_docs to relax the guillemets rule.

## Out of scope

- **[`gizlilik-politikasi.html`](gizlilik-politikasi.html) + [`kullanim-kosullari.html`](kullanim-kosullari.html)** — legal long-form, keep title-case headings per Turkish legal document convention.
- **[`privacy-policy.html`](privacy-policy.html) + [`terms-of-use.html`](terms-of-use.html)** — English mirrors, follow English title-case convention.
- **[`brand-book.html`](brand-book.html)** — handled in #53 (separate rewrite).

## Test plan

- [ ] Visual pass on `/`, `/404.html`, header, and footer — copy reads naturally, no accidental lowercasing of proper nouns.
- [ ] CI passes (html-validate / pa11y / Lighthouse / lychee).
- [ ] Browser tab titles on `/` and `/404.html` match the new frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)