### PR TITLE
Ignore, macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ _site/
 
 # Lighthouse CI reports
 .lighthouseci/
+
+# macOS Finder metadata
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
## Summary
- Add `.DS_Store` + `**/.DS_Store` to `.gitignore` so macOS Finder metadata never gets tracked.

Noticed during the 2026-04-21 session-start scan — three untracked `.DS_Store` files were sitting in the working tree (`.`, `img/`, `img/logos/`). No existing ignore rule covered them.

## Test plan
- [ ] `git status` in a fresh clone shows no `.DS_Store` noise after a Finder visit.