### PR TITLE
Add, Inter type-scale helper classes (caption/small/lead)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+Notable changes to the `www.dipnot.app` landing site.
+
+Format: reverse chronological, one heading per date (`## YYYY-MM-DD`),
+one bullet per change with a PR link when available. Keep entries
+terse — the commit message and PR body carry the full reasoning.
+
+## 2026-04-21
+
+- **Typography** — Added `.text-caption` (12 px), `.text-small` (14 px),
+  and `.text-lead` (18 px) helper classes in [`css/styles.css`](css/styles.css)
+  for the canonical type-scale tokens Bulma doesn't cover (Bulma jumps
+  16 → 20 with no 18 step). Completes the Inter adoption ask from
+  `core_docs/communication/to-landing.md` (2026-04-19). Spec:
+  [`core_docs/product-design/typography.md`](../core_docs/product-design/typography.md).
+  Closes [#52](https://github.com/Dipnot-App/www.dipnot.app/issues/52).
+
+## 2026-04-19
+
+- **Typography** — Loaded **Inter** via Google Fonts CDN in
+  [`_includes/layouts/base.njk`](_includes/layouts/base.njk) (with
+  preconnect hints) and overrode Bulma's default font stack in
+  [`css/styles.css`](css/styles.css) so body, headings, `.title`, and
+  `.subtitle` all pick up Inter. Cross-surface font ratified in
+  [`core_docs/product-design/typography.md`](../core_docs/product-design/typography.md)
+  (landed via core_docs PR #67 / issue #18). Landed via
+  [PR #50](https://github.com/Dipnot-App/www.dipnot.app/pull/50).

--- a/_data/site.json
+++ b/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
-  "cssVersion": "260419_1",
+  "cssVersion": "260421_1",
   "jsVersion": "260417_2",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",

--- a/css/styles.css
+++ b/css/styles.css
@@ -9,6 +9,11 @@ h1, h2, h3, h4, h5, h6,
   font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
 
+/* Type-scale helpers for tokens Bulma doesn't cover (caption 12 / small 14 / lead 18) */
+.text-caption { font-size: 12px; line-height: 1.5; }
+.text-small   { font-size: 14px; line-height: 1.5; }
+.text-lead    { font-size: 18px; line-height: 1.5; }
+
 .navbar.is-fixed-top {
   box-shadow: 0 0 10px black;
 }


### PR DESCRIPTION
Closes #52.

## Summary
- Adds `.text-caption` (12 px), `.text-small` (14 px), `.text-lead` (18 px) helper classes in [`css/styles.css`](css/styles.css) for the canonical type-scale tokens Bulma doesn't cover (Bulma jumps 16 → 20 with no 18 step).
- Creates root `CHANGELOG.md` — first entry covers PR #50 (Inter font load) and this PR.
- Bumps `cssVersion` `260419_1` → `260421_1` in `_data/site.json` so browsers pick up the new classes.

Completes the Inter adoption ask in `core_docs/communication/to-landing.md` (2026-04-19). Spec: [`core_docs/product-design/typography.md`](https://github.com/Dipnot-App/core_docs/blob/main/product-design/typography.md) → "Landing — Bulma + custom CSS".

## Canonical scale mapping (landing)
| Token | CSS |
| --- | --- |
| caption (12) | `.text-caption` |
| small (14) | `.text-small` |
| body (16) | `is-size-6` (Bulma) |
| lead (18) | `.text-lead` |
| h3 (20) | `is-size-5` (Bulma) |
| h2 (24) | `is-size-4` (Bulma) |
| h1 (32) | `is-size-3` (Bulma) |
| display (48) | `is-size-1` (Bulma) |

## Test plan
- [ ] `npm run build` succeeds (verified locally).
- [ ] `npm run check:html` passes.
- [ ] Visual spot-check: a test element with each of the 3 new classes renders at the expected size in light + dark.
- [ ] After merge: write ack to `core_docs/communication/to-core-docs.md` and delete the ask from `to-landing.md`.