### PR TITLE
Fix, all html-validate errors flagged in check:html

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -5,11 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="author" content="{{ site.author }}">
   <meta name="description" content="{{ description }}">
-  {% if keywords %}<meta name="keywords" content="{{ keywords }}">{% endif %}
+  {%- if keywords %}
+  <meta name="keywords" content="{{ keywords }}">
+  {%- endif %}
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="geolocation=(), camera=(), microphone=(), payment=()">
   <meta name="theme-color" content="{{ site.themeColor }}">
-  {% if robots %}<meta name="robots" content="{{ robots }}">{% endif %}
+  {%- if robots %}
+  <meta name="robots" content="{{ robots }}">
+  {%- endif %}
   {%- for alt in hreflang %}
   <link rel="alternate" hreflang="{{ alt.lang }}" href="{{ alt.href }}">
   {%- endfor %}
@@ -19,7 +23,9 @@
   <meta property="og:type" content="{{ og.type or 'website' }}">
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:locale" content="{{ og.locale or 'tr_TR' }}">
-  {% if og.localeAlternate %}<meta property="og:locale:alternate" content="{{ og.localeAlternate }}">{% endif %}
+  {%- if og.localeAlternate %}
+  <meta property="og:locale:alternate" content="{{ og.localeAlternate }}">
+  {%- endif %}
   <meta property="og:title" content="{{ og.title or title }}">
   <meta property="og:description" content="{{ og.description or description }}">
   <meta property="og:url" content="{{ og.url }}">

--- a/_includes/partials/nav.njk
+++ b/_includes/partials/nav.njk
@@ -22,12 +22,12 @@
           </button>
         </div>
 
-        <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar">
+        <button type="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar">
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
-        </a>
+        </button>
       </div>
     </div>
 

--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -47,33 +47,33 @@ og:
       <table class="table">
         <thead>
           <tr>
-            <th>Veri Kategorisi</th>
-            <th>Toplanan Veriler</th>
-            <th>İşleme Amacı</th>
-            <th>Hukuki Sebep (KVKK md. 5)</th>
+            <th scope="col">Veri Kategorisi</th>
+            <th scope="col">Toplanan Veriler</th>
+            <th scope="col">İşleme Amacı</th>
+            <th scope="col">Hukuki Sebep (KVKK md. 5)</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <th>Kimlik Bilgisi</th>
+            <th scope="row">Kimlik Bilgisi</th>
             <td>Ad, Soyad</td>
             <td>Hesap oluşturma, kullanıcıları tanımlama, profilleri kişiselleştirme</td>
             <td>Açık rıza</td>
           </tr>
           <tr>
-            <th>İletişim Bilgisi</th>
+            <th scope="row">İletişim Bilgisi</th>
             <td>E-posta adresi, Telefon numarası</td>
             <td>Hesap doğrulama (e-posta doğrulama), şifre yenileme, bildirim gönderme, kullanıcı ile iletişim</td>
             <td>Açık rıza</td>
           </tr>
           <tr>
-            <th>Kullanım Verileri</th>
+            <th scope="row">Kullanım Verileri</th>
             <td>Okunan makaleler, beğeniler, kaydedilen içerikler, oturum süreleri</td>
             <td>İçerik önerileri sunma, deneyimi iyileştirme, trend analizi</td>
             <td>Meşru menfaat</td>
           </tr>
           <tr>
-            <th>Teknik Veriler</th>
+            <th scope="row">Teknik Veriler</th>
             <td>Cihaz modeli, işletim sistemi sürümü, IP adresi, uygulama sürümü</td>
             <td>Uygulamanın çalışmasını sağlama, hata ayıklama, güvenlik</td>
             <td>Meşru menfaat</td>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -51,33 +51,33 @@ og:
       <table class="table">
         <thead>
           <tr>
-            <th>Data Category</th>
-            <th>Data Collected</th>
-            <th>Purpose of Processing</th>
-            <th>Legal Basis (KVKK art. 5)</th>
+            <th scope="col">Data Category</th>
+            <th scope="col">Data Collected</th>
+            <th scope="col">Purpose of Processing</th>
+            <th scope="col">Legal Basis (KVKK art. 5)</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <th>Identity</th>
+            <th scope="row">Identity</th>
             <td>First name, Last name</td>
             <td>Account creation, identifying users, personalising profiles</td>
             <td>Explicit consent</td>
           </tr>
           <tr>
-            <th>Contact</th>
+            <th scope="row">Contact</th>
             <td>Email address, Phone number</td>
             <td>Account verification (email verification), password reset, sending notifications, communicating with the user</td>
             <td>Explicit consent</td>
           </tr>
           <tr>
-            <th>Usage Data</th>
+            <th scope="row">Usage Data</th>
             <td>Articles read, likes, saved content, session durations</td>
             <td>Content recommendations, improving the experience, trend analysis</td>
             <td>Legitimate interest</td>
           </tr>
           <tr>
-            <th>Technical Data</th>
+            <th scope="row">Technical Data</th>
             <td>Device model, operating system version, IP address, app version</td>
             <td>Ensuring the app works, debugging, security</td>
             <td>Legitimate interest</td>


### PR DESCRIPTION
Contributes to epic #32.

## Summary
Clears every error surfaced by `npm run check:html` (30 → 0) so the hard-gate switch from `continue-on-error: true` is one step closer.

Three root-cause fixes, four files touched:

| Root cause | Fix | File |
|---|---|---|
| `{% if %}` conditional meta tags rendered blank lines with trailing whitespace when the frontmatter key was unset | Swap to `{%- if %}…{%- endif %}` whitespace-control and put the meta tag on its own line | [`_includes/layouts/base.njk`](_includes/layouts/base.njk) |
| Bulma's legacy `<a role="button" class="navbar-burger">` triggers `prefer-native-element` | Swap to `<button type="button" class="navbar-burger">`; JS click handler keys off `.navbar-burger` so unchanged | [`_includes/partials/nav.njk`](_includes/partials/nav.njk) |
| Personal-data processor tables had `<th>` cells without a `scope` attribute (`wcag/h63`) | Add `scope="col"` to the 4 `<thead>` cells and `scope="row"` to the 4 `<tbody>` row-header cells | [`gizlilik-politikasi.html`](gizlilik-politikasi.html) + [`privacy-policy.html`](privacy-policy.html) |

## Test plan
- [x] `npm run build && npm run check:html` exits 0 locally (was 30 errors).
- [ ] Visual spot-check the navbar-burger on mobile — mobile menu still opens + closes after the `<a>` → `<button>` swap.
- [ ] Visual spot-check the processor table on `/gizlilik-politikasi.html` and `/privacy-policy.html` — layout unchanged.
- [ ] CI `html-validate` step passes cleanly (no soft errors reported).