### PR TITLE
Mirror, Expo OTA + GA US-servers additions into privacy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ terse — the commit message and PR body carry the full reasoning.
 
 ## 2026-04-21
 
+- **Privacy policy** — Mirrored the Expo (Push + OTA Updates) and
+  Google Analytics US-servers additions from
+  [`core_docs/data-processors.md`](../core_docs/data-processors.md)
+  into [`gizlilik-politikasi.html`](gizlilik-politikasi.html) (TR,
+  authoritative) and [`privacy-policy.html`](privacy-policy.html) (EN
+  mirror). Expo entry now covers OTA launch-time pings to
+  `u.expo.dev` (app install ID, runtime version, update channel)
+  alongside push tokens + stability metadata. GA entry gained a
+  closing sentence disclosing USA processing (no user-configurable
+  region on standard Firebase projects). Bumped `Son Güncelleme` /
+  `Last updated` to 2026-04-21. Contributes to epic
+  [#30](https://github.com/Dipnot-App/www.dipnot.app/issues/30).
 - **HTML quality** — Cleared every error surfaced by
   `npm run check:html` (30 → 0). Root causes: Nunjucks `{% if %}`
   conditional meta tags leaving trailing whitespace when a frontmatter

--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -33,7 +33,7 @@ og:
   <section class="section">
     <div class="content">
       <h1>Gizlilik Politikası ve Aydınlatma Metni (KVKK)</h1>
-      <p><strong>Son Güncelleme:</strong> <time datetime="2026-04-17">17 Nisan 2026</time></p>
+      <p><strong>Son Güncelleme:</strong> <time datetime="2026-04-21">21 Nisan 2026</time></p>
 
       <h2>1. Veri Sorumlusu ve Temsilcisi</h2>
       <p>6698 sayılı Kişisel Verilerin Korunması Kanunu ("KVKK") uyarınca, kişisel verileriniz "Dipnot" uygulamasını yöneten ekip tarafından veri sorumlusu sıfatıyla aşağıda açıklanan kapsamda işlenecektir.</p>
@@ -92,12 +92,12 @@ og:
         <li>
           <strong>Expo (Expo Application Services, Inc. – ABD):</strong>
           <br>
-          <span>Dipnot mobil uygulaması Expo / React Native altyapısıyla geliştirilmiştir. Push bildirim tokenlarınız Expo Push servisi üzerinden işlenir ve bildirim gönderiminde kullanılır. Uygulama kararlılığını ölçmek ve hata ayıklamak amacıyla sınırlı cihaz ve çalışma zamanı bilgileri (cihaz modeli, işletim sistemi sürümü, uygulama sürümü) Expo'nun ABD'deki sunucularına iletilebilir. Bu aktarım KVKK'nın 9. maddesi kapsamında açık rızanıza dayanılarak gerçekleştirilir.</span>
+          <span>Dipnot mobil uygulaması Expo / React Native altyapısıyla geliştirilmiştir. Push bildirim tokenlarınız Expo Push servisi üzerinden işlenir ve bildirim gönderiminde kullanılır. Uygulama kararlılığını ölçmek ve hata ayıklamak amacıyla sınırlı cihaz ve çalışma zamanı bilgileri (cihaz modeli, işletim sistemi sürümü, uygulama sürümü) Expo'nun ABD'deki sunucularına iletilebilir. Ayrıca uygulama her açılışında Expo sunucularına (<code>u.expo.dev</code>) hafif bir sorgu göndererek yeni bir JavaScript/varlık güncellemesi olup olmadığını kontrol eder (OTA — "over-the-air" güncelleme); bu sorguda uygulama kimliği, çalışma zamanı sürümü ve güncelleme kanalı bilgisi yer alır. Bu aktarımlar KVKK'nın 9. maddesi kapsamında açık rızanıza dayanılarak gerçekleştirilir.</span>
         </li>
         <li>
           <strong>Google Analytics (Firebase için Google Analytics):</strong>
           <br>
-          <span>Mobil uygulamadaki kullanım istatistiklerini analiz etmek, kullanıcı davranışlarını anlamak ve deneyimi iyileştirmek amacıyla. Toplanan veriler arasında cihaz tanımlayıcıları, oturum süreleri, ekran görüntülemeleri ve uygulama içi etkileşim olayları yer alır. Bu verileri pazarlama veya üçüncü taraf reklam ağlarıyla paylaşmıyoruz.</span>
+          <span>Mobil uygulamadaki kullanım istatistiklerini analiz etmek, kullanıcı davranışlarını anlamak ve deneyimi iyileştirmek amacıyla. Toplanan veriler arasında cihaz tanımlayıcıları, oturum süreleri, ekran görüntülemeleri ve uygulama içi etkileşim olayları yer alır. Bu verileri pazarlama veya üçüncü taraf reklam ağlarıyla paylaşmıyoruz. Analytics verileri Google'ın ABD'deki sunucularında işlenir (Firebase için Google Analytics — standart Firebase projelerinde kullanıcı tarafından yapılandırılabilir bir bölge ayarı bulunmamaktadır).</span>
         </li>
         <li>
           <strong>Firebase Cloud Functions — İletişim Formu (Google LLC, us-central1 – ABD):</strong>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -33,7 +33,7 @@ og:
   <section class="section">
     <div class="content">
       <h1>Privacy Policy (KVKK)</h1>
-      <p><strong>Last updated:</strong> <time datetime="2026-04-17">17 April 2026</time></p>
+      <p><strong>Last updated:</strong> <time datetime="2026-04-21">21 April 2026</time></p>
 
       <div class="notification is-warning">
         <p><strong>Note:</strong> This English version is provided for convenience. The Turkish version, <a href="/gizlilik-politikasi.html">Gizlilik Politikası ve Aydınlatma Metni</a>, is authoritative under Turkish law (KVKK) in case of any conflict.</p>
@@ -96,12 +96,12 @@ og:
         <li>
           <strong>Expo (Expo Application Services, Inc. – USA):</strong>
           <br>
-          <span>The Dipnot mobile app is built on the Expo / React Native stack. Your push notification tokens are processed through the Expo Push service and used to deliver notifications. Limited device and runtime information (device model, operating system version, app version) may be sent to Expo's servers in the USA for stability monitoring and debugging. This transfer is carried out based on your explicit consent under KVKK article 9.</span>
+          <span>The Dipnot mobile app is built on the Expo / React Native stack. Your push notification tokens are processed through the Expo Push service and used to deliver notifications. Limited device and runtime information (device model, operating system version, app version) may be sent to Expo's servers in the USA for stability monitoring and debugging. Additionally, on every app launch the app sends a lightweight request to Expo's servers (<code>u.expo.dev</code>) to check whether a new JavaScript/asset update is available (OTA — "over-the-air" update); this request includes the app install ID, runtime version, and update channel. These transfers are carried out based on your explicit consent under KVKK article 9.</span>
         </li>
         <li>
           <strong>Google Analytics (Google Analytics for Firebase):</strong>
           <br>
-          <span>Used to analyse in-app usage statistics, understand user behaviour, and improve the experience. Data collected includes device identifiers, session durations, screen views, and in-app interaction events. We do not share this data with marketing or third-party ad networks.</span>
+          <span>Used to analyse in-app usage statistics, understand user behaviour, and improve the experience. Data collected includes device identifiers, session durations, screen views, and in-app interaction events. We do not share this data with marketing or third-party ad networks. Analytics data is processed on Google's servers in the USA (Google Analytics for Firebase — standard Firebase projects have no user-configurable region setting).</span>
         </li>
         <li>
           <strong>Firebase Cloud Functions — Contact form (Google LLC, us-central1 – USA):</strong>


### PR DESCRIPTION
Contributes to epic #30.

## Summary
Mirrors the Expo (Push + OTA Updates) and Google Analytics additions landed in [`core_docs/data-processors.md`](https://github.com/Dipnot-App/core_docs/blob/main/data-processors.md) (core_docs PR #55) into the landing-side privacy policy pages. Fulfils the 2026-04-20 core_docs→landing ask (which supersedes the 2026-04-19 mobile→landing ask).

## Changes

- **Expo block** in both [`gizlilik-politikasi.html`](gizlilik-politikasi.html) (TR, authoritative) and [`privacy-policy.html`](privacy-policy.html) (EN mirror): existing push-tokens + stability-metadata prose extended with the OTA (`expo-updates`) launch-time ping to `u.expo.dev`, disclosing app install ID + runtime version + update channel. Both transfers remain under KVKK article 9 explicit consent.
- **Google Analytics block** in both files: appends a closing sentence disclosing that Analytics data is processed on Google's US servers, with a parenthetical noting standard Firebase projects have no user-configurable region (GA 360 not enabled).
- Bumps `Son Güncelleme` (TR) and `Last updated` (EN) to `2026-04-21`.
- `CHANGELOG.md` entry under `## 2026-04-21`.

## Source-of-truth compliance
Both snippets copied verbatim from `data-processors.md` per the rule at the top of that file. `u.expo.dev` wrapped in `<code>` tags to match the existing HTML convention for technical identifiers (e.g. `<code>contactSubmissions</code>` in the Firebase Cloud Functions entry).

## Test plan
- [x] `npm run build && npm run check:html` — zero errors.
- [ ] Visual render of `/gizlilik-politikasi.html` + `/privacy-policy.html` — Expo + GA sections read correctly and maintain layout.
- [ ] After merge: write ack into `core_docs/communication/to-core-docs.md` referencing this PR; delete the 2026-04-20 core_docs→landing ask AND the superseded 2026-04-19 mobile→landing ask from `to-landing.md`; also delete the 2026-04-20 "New rules ratified" FYI that was read during session-start.