### PR TITLE
Log, logo-filename audit (0 renames — already compliant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ terse — the commit message and PR body carry the full reasoning.
 
 ## 2026-04-21
 
+- **Brand assets** — Audited every brand-logo reference against the
+  [asset-naming rule](../core_docs/product-design/logo.md#naming-rule)
+  ratified in `core_docs` on 2026-04-20. Result: **0 renames needed.**
+  [`img/logos/`](img/logos/) already carries all 9 master filenames
+  (6 solo + 3 composed) as both SVG and PNG exports, matching
+  [`core_docs/assets/logo/`](../core_docs/assets/logo/). All
+  references in code ([`_includes/partials/nav.njk`](_includes/partials/nav.njk),
+  [`_includes/partials/footer.njk`](_includes/partials/footer.njk),
+  [`brand-book.html`](brand-book.html)) already use the master names
+  (`logo.svg`, `logo-gold.svg`, `logo-white-on-teal.svg`,
+  `logo-white-on-sky-captain.svg`). Favicon set at repo root
+  (`favicon.ico`, `favicon-16x16.png`, `favicon-32x32.png`,
+  `apple-touch-icon.png`, `android-chrome-192x192.png`,
+  `android-chrome-512x512.png`) keeps its platform-standard filenames
+  per the rule's exception clause.
 - **Privacy policy** — Mirrored the Expo (Push + OTA Updates) and
   Google Analytics US-servers additions from
   [`core_docs/data-processors.md`](../core_docs/data-processors.md)


### PR DESCRIPTION
Resolves the 2026-04-20 core_docs→landing ask: *Align logo filenames in `www_dipnot_app/` with the master names per the new asset-naming rule.*

## Summary
Audited every brand-logo asset and reference against the [asset-naming rule](https://github.com/Dipnot-App/core_docs/blob/main/product-design/logo.md#naming-rule). **Result: 0 renames needed — landing is already fully compliant.**

This PR is doc-only: one `CHANGELOG.md` entry recording the audit so a future re-audit doesn't have to re-discover this.

## Audit findings

### Assets in [`img/logos/`](img/logos/) — ✅ all 9 master filenames present
| Filename | Master? | Notes |
|---|---|---|
| `logo.svg` / `logo.png` | ✅ | Default teal mark (`#338596`) — master is also named `logo.svg` |
| `logo-gold.svg` / `.png` | ✅ | |
| `logo-white.svg` / `.png` | ✅ | |
| `logo-black.svg` / `.png` | ✅ | |
| `logo-winter-bloom.svg` / `.png` | ✅ | |
| `logo-sky-captain.svg` / `.png` | ✅ | |
| `logo-white-on-teal.svg` / `.png` | ✅ | Composed variant |
| `logo-white-on-sky-captain.svg` / `.png` | ✅ | Composed variant |
| `logo-teal-on-sky-captain.svg` / `.png` | ✅ | Composed variant |

PNG exports are local-only (no master PNGs exist in `core_docs/assets/logo/`) and correctly named after their SVG master per the rule.

### References in code — ✅ all use master filenames
- `_includes/partials/nav.njk:6` → `logo.svg`
- `_includes/partials/footer.njk:10` → `logo.svg`
- `brand-book.html:38,46,54,62` → `logo.svg`, `logo-gold.svg`, `logo-white-on-teal.svg`, `logo-white-on-sky-captain.svg`

### Exception-clause files (not subject to the rule)
- Favicon set at repo root: `favicon.ico`, `favicon-16x16.png`, `favicon-32x32.png`, `apple-touch-icon.png`, `android-chrome-192x192.png`, `android-chrome-512x512.png` — platform-standard filenames
- Non-brand graphics: `google-play.svg`, `app-store.svg` (store badges); `deviceframes-*.png`, `apw-Icon*.png`, `about.webp`, `faq.webp`, `hero.webp` (product shots)

## Test plan
- [x] Every `<img>` / `<link>` tag reference confirmed to resolve to a master filename.
- [x] `img/logos/` listing matches `core_docs/assets/logo/` 1:1 for SVG variants.
- [ ] After merge: write ack into `core_docs/communication/to-core-docs.md` and delete the logo-rename ask from `to-landing.md`.