### PR TITLE
Harden, html-validate CI step (drop continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Validate HTML
         run: npm run check:html
-        continue-on-error: true
 
       - name: Serve _site on :8080
         run: npx http-server _site -p 8080 --silent &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ terse — the commit message and PR body carry the full reasoning.
 
 ## 2026-04-21
 
+- **CI** — Removed `continue-on-error: true` from the `Validate HTML`
+  step in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — now
+  a hard gate. Enabled by [PR #60](https://github.com/Dipnot-App/www.dipnot.app/pull/60)
+  clearing all 30 pre-existing errors. Pa11y + Lighthouse remain soft
+  until their own backlogs are cleared (tracked under epic
+  [#32](https://github.com/Dipnot-App/www.dipnot.app/issues/32)).
 - **Brand assets** — Audited every brand-logo reference against the
   [asset-naming rule](../core_docs/product-design/logo.md#naming-rule)
   ratified in `core_docs` on 2026-04-20. Result: **0 renames needed.**


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from the `Validate HTML` step in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). New HTML issues now fail the build and block merge.
- Safe to flip because [#60](https://github.com/Dipnot-App/www.dipnot.app/pull/60) cleared all 30 pre-existing errors; local `npm run check:html` has been exit-0 since.
- CHANGELOG entry added.

Pa11y + Lighthouse steps stay soft-gated (each still has its own backlog under epic #32).

## Test plan
- [ ] CI run on this PR passes cleanly (html-validate exits 0).
- [ ] A follow-up PR that intentionally introduces a broken `<th>` or trailing-whitespace issue would fail — proving the gate works. (Don't actually land such a PR; just reasoning about the guardrail.)