### PR TITLE
Tweak, hide placeholder socials + wire Google Play to Expo build

### DIFF
--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -35,7 +35,7 @@
           </a>
 
           <!-- TODO: add Twitter social media link -->
-          <a href="https://www.instagram.com/dipnot.app" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="X" aria-label="Dipnot'u X'te takip et">
+          <a href="https://www.instagram.com/dipnot.app" target="_blank" rel="noopener noreferrer" class="button is-rounded is-hidden" title="X" aria-label="Dipnot'u X'te takip et">
             <span class="icon is-small">
               <i class="fa-brands fa-x-twitter"></i>
             </span>
@@ -49,14 +49,14 @@
           </a>
 
           <!-- Theorg social media link -->
-          <a href="https://theorg.com/org/dipnot-1" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="The Org" aria-label="Dipnot'u The Org'da görüntüle">
+          <a href="https://theorg.com/org/dipnot-1" target="_blank" rel="noopener noreferrer" class="button is-rounded is-hidden" title="The Org" aria-label="Dipnot'u The Org'da görüntüle">
             <span class="icon is-small">
               <i class="fa-solid fa-sitemap"></i>
             </span>
           </a>
 
           <!-- Stackshare social media link -->
-          <a href="https://stackshare.io/nevcanuludas/dipnot-app" target="_blank" rel="noopener noreferrer" class="button is-rounded" title="Stack Share" aria-label="Dipnot'un teknoloji yığınını Stack Share'de görüntüle">
+          <a href="https://stackshare.io/nevcanuludas/dipnot-app" target="_blank" rel="noopener noreferrer" class="button is-rounded is-hidden" title="Stack Share" aria-label="Dipnot'un teknoloji yığınını Stack Share'de görüntüle">
             <span class="icon is-small">
               <i class="fa-solid fa-share-nodes"></i>
             </span>
@@ -114,10 +114,10 @@
           <p class="menu-label">Uygulamayı indir</p>
 
           <div class="buttons are-small">
-            <button type="button" class="button is-light is-inverted is-outlined is-rounded">
+            <a href="https://expo.dev/accounts/vac-studio/projects/dipnotAPP/builds/deb04b0e-2829-4ef9-aaca-6644c4867bfc" target="_blank" rel="noopener noreferrer" class="button is-light is-inverted is-outlined is-rounded">
               <img src="/img/svg/google-play.svg" alt="Google Play">
               <span class="ml-2">Google Play</span>
-            </button>
+            </a>
             <button type="button" class="button is-light is-rounded">
               <img src="/img/svg/app-store.svg" alt="App Store">
               <span class="ml-2">App Store</span>


### PR DESCRIPTION
## Summary

- Hide three placeholder social buttons (X, The Org, Stack Share) with Bulma's `is-hidden` until real destinations exist — markup stays so re-enabling is one-line.
- Convert Google Play footer `<button>` placeholder into an `<a>` pointing to the current Expo Android build. Added `rel="noopener noreferrer"` per the security baseline; dropped the invalid `type="button"` attribute that `<a>` doesn't take.

## Notes

- App Store button stays as a disabled `<button>` — no live iOS build to link to yet.
- Expo build URL is the current Android artifact (`deb04b0e…`). Swap to a Play Store listing URL when Dipnot lists.

## Test plan

- [ ] `npm run build && npm run check:html` stays green (anchor now has `rel`, no stray `type` attribute)
- [ ] Local preview — three hidden social buttons disappear; Google Play button navigates to Expo build in new tab
- [ ] Dark / light theme unaffected