### PR TITLE
Flip, Cloud Function fetch URLs to europe-west1 (Phase B)

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -2,7 +2,7 @@
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
   "cssVersion": "260421_1",
-  "jsVersion": "260417_2",
+  "jsVersion": "260424_1",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",
   "ogImage": "https://dipnot.app/android-chrome-512x512.png",

--- a/js/contact.js
+++ b/js/contact.js
@@ -35,7 +35,7 @@
       };
 
       const res = await fetch(
-        "https://us-central1-dipnotapp.cloudfunctions.net/submitContactForm",
+        "https://europe-west1-dipnotapp.cloudfunctions.net/submitContactForm",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/js/newsletter.js
+++ b/js/newsletter.js
@@ -17,7 +17,7 @@
 
     try {
       const res = await fetch(
-        "https://us-central1-dipnotapp.cloudfunctions.net/subscribeNewsletter",
+        "https://europe-west1-dipnotapp.cloudfunctions.net/subscribeNewsletter",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

Phase B of the `us-central1 → europe-west1` migration. The functions
were migrated blue/green on 2026-04-21 (co-locating with `eur3`
Firestore). Two landing-side fetch URLs flip to the EU endpoint:

- [`js/newsletter.js:20`](../blob/chore/phase-b-functions-europe-west1/js/newsletter.js#L20) — `subscribeNewsletter`
- [`js/contact.js:38`](../blob/chore/phase-b-functions-europe-west1/js/contact.js#L38) — `submitContactForm`

Old region stays live during Phase C (48 h after all callers flip),
so no downtime risk if this rolls out before the functions retirement.

`jsVersion` in `_data/site.json` bumped for cache-bust.

## Context

- Functions ask: [`core_docs/communication/to-landing.md`](https://github.com/Dipnot-App/core_docs/blob/main/communication/to-landing.md) → functions 2026-04-21
- Migration issue: [FirebaseFunctions#26](https://github.com/Dipnot-App/FirebaseFunctions/issues/26)
- Policy pages (`gizlilik-politikasi.html` / `privacy-policy.html`)
  still say `us-central1`. That's Phase D, gated on Phase C; separate PR.

## Test plan

- [ ] `npm run build` passes locally
- [ ] `npm run serve` — submit a test newsletter signup → lands in Firestore `newsletter_subscribers`
- [ ] `npm run serve` — submit a test contact form → lands in `contactSubmissions`; rate-limit state writes cleanly
- [ ] Browser devtools confirm POST hits `europe-west1-dipnotapp.cloudfunctions.net` with HTTP 200
- [ ] CORS preflight (OPTIONS) returns 204 with `Access-Control-Allow-Origin: https://dipnot.app`