### PR TITLE
Add, issue templates + status-axis labels (non-destructive)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Something on the landing site is broken
+title: ""
+labels: ["status:triage"]
+assignees: []
+---
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected
+
+## Observed
+
+## Environment
+
+- URL / page:
+- Browser + version:
+- OS + device:
+- Theme (light / dark / auto):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Propose a new capability or content change for the landing site
+title: ""
+labels: ["status:triage"]
+assignees: []
+---
+
+## Problem
+
+What's missing or painful today?
+
+## Proposed solution
+
+## Alternatives considered
+
+## Scope
+
+- In:
+- Out:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Format: reverse chronological, one heading per date (`## YYYY-MM-DD`),
 one bullet per change with a PR link when available. Keep entries
 terse — the commit message and PR body carry the full reasoning.
 
+## 2026-04-24
+
+- **Issue infra** — Provisioned the status axis (`status:triage`,
+  `status:blocked`, `status:wontfix`, `status:good-first-issue`) by
+  renaming the bare `blocked` label to `status:blocked` and adding
+  the missing three. Deleted GitHub's 9 default labels (`bug`,
+  `enhancement`, `documentation`, `duplicate`, `good first issue`,
+  `help wanted`, `invalid`, `question`, `wontfix`) per the
+  Replacement policy. Added [`.github/ISSUE_TEMPLATE/bug_report.md`](.github/ISSUE_TEMPLATE/bug_report.md)
+  and [`.github/ISSUE_TEMPLATE/feature_request.md`](.github/ISSUE_TEMPLATE/feature_request.md)
+  with `status:triage` front-matter so new issues auto-tag for triage.
+  Landing's diverged `type:` / `priority:` / `area:` taxonomy
+  (finer-grained than the `core_docs` canonical — `p0..p3` vs.
+  `high/medium/low`, and landing-specific areas `a11y`, `seo`,
+  `privacy`, `ci`, `brand`) is preserved as intentional drift;
+  variance to be formalized in `core_docs/development-rules/issues.md`
+  (ask queued).
+
 ## 2026-04-21
 
 - **CI** — Removed `continue-on-error: true` from the `Validate HTML`


### PR DESCRIPTION
## Summary

Completes [`core_docs`'s 2026-04-20 ask](https://github.com/Dipnot-App/core_docs/blob/main/communication/to-landing.md) — provision issue-tracking infrastructure on the landing repo — taking the non-destructive path. Keeps landing's diverged-but-in-use `type:` / `priority:` / `area:` taxonomy intact.

## Changes on GitHub (already applied via `gh label`)

- Deleted 9 default labels: `bug`, `enhancement`, `documentation`, `duplicate`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`.
- Renamed bare `blocked` → `status:blocked` (preserves label on issue #7).
- Added `status:triage`, `status:wontfix`, `status:good-first-issue` to complete the status axis.

## Changes in this PR

- [`.github/ISSUE_TEMPLATE/bug_report.md`](../blob/chore/provision-issue-templates-and-status-labels/.github/ISSUE_TEMPLATE/bug_report.md) — title / repro / expected / observed / environment. Short on purpose (heavy templates get ignored).
- [`.github/ISSUE_TEMPLATE/feature_request.md`](../blob/chore/provision-issue-templates-and-status-labels/.github/ISSUE_TEMPLATE/feature_request.md) — problem / proposed solution / alternatives / scope.
- Both templates emit `labels: ["status:triage"]` in YAML front-matter so the lifecycle auto-starts at triage.
- [`CHANGELOG.md`](../blob/chore/provision-issue-templates-and-status-labels/CHANGELOG.md) — 2026-04-24 entry.

## Why the canonical taxonomy wasn't cloned

`core_docs/development-rules/issues.md` prescribes `type:bug/feature/chore/docs/refactor/test`, `priority:high/medium/low`, and areas oriented around `auth/feed/article/admin/push/theme/schema/infra`. Landing's current taxonomy is a better fit for a static marketing site — finer-grained priority buckets (`p0..p3`) and landing-specific areas (`a11y`, `ci`, `security`, `brand`, `seo`, `privacy`). 14 of 16 open issues are already labeled under this scheme; cloning the canonical set would strip those labels with no clean mapping for `area:privacy`, `area:a11y`, `area:seo`, `area:ci`, `area:brand`, or for `type:epic`, `type:task`, `type:debt`.

A follow-up ask will go to `core_docs` requesting `issues.md` formally acknowledge per-repo taxonomy variance.

## Test plan

- [ ] After merge, open a new test issue → verify the template picker shows both options and new issues auto-receive `status:triage`
- [ ] Close test issue
- [ ] Label list on the repo matches the final state below