### PR TITLE
Sync, privacy-policy HTMLs to europe-west1 snippets (Phase D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ terse — the commit message and PR body carry the full reasoning.
 
 ## 2026-04-24
 
+- **Privacy (Phase D)** — Regenerated the Firebase Cloud Functions
+  (contact form) entry in [`gizlilik-politikasi.html`](gizlilik-politikasi.html)
+  and [`privacy-policy.html`](privacy-policy.html) to reflect the
+  `us-central1` → `europe-west1` migration (Belgium, EU). Dropped the
+  KVKK art. 9 cross-border framing from the contact-form snippet —
+  processing is now inside EU/EEA, matching the `eur3` Firebase entry
+  pattern. Snippets pulled verbatim from the registry at
+  [`core_docs/data-processors.md`](../core_docs/data-processors.md).
+  Bumped `Son Güncelleme` / `Last updated` to 2026-04-24 in both
+  files. Closes the `core_docs` 2026-04-21 Phase D ask.
 - **Issue infra** — Provisioned the status axis (`status:triage`,
   `status:blocked`, `status:wontfix`, `status:good-first-issue`) by
   renaming the bare `blocked` label to `status:blocked` and adding

--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -33,7 +33,7 @@ og:
   <section class="section">
     <div class="content">
       <h1>Gizlilik Politikası ve Aydınlatma Metni (KVKK)</h1>
-      <p><strong>Son Güncelleme:</strong> <time datetime="2026-04-21">21 Nisan 2026</time></p>
+      <p><strong>Son Güncelleme:</strong> <time datetime="2026-04-24">24 Nisan 2026</time></p>
 
       <h2>1. Veri Sorumlusu ve Temsilcisi</h2>
       <p>6698 sayılı Kişisel Verilerin Korunması Kanunu ("KVKK") uyarınca, kişisel verileriniz "Dipnot" uygulamasını yöneten ekip tarafından veri sorumlusu sıfatıyla aşağıda açıklanan kapsamda işlenecektir.</p>
@@ -100,9 +100,9 @@ og:
           <span>Mobil uygulamadaki kullanım istatistiklerini analiz etmek, kullanıcı davranışlarını anlamak ve deneyimi iyileştirmek amacıyla. Toplanan veriler arasında cihaz tanımlayıcıları, oturum süreleri, ekran görüntülemeleri ve uygulama içi etkileşim olayları yer alır. Bu verileri pazarlama veya üçüncü taraf reklam ağlarıyla paylaşmıyoruz. Analytics verileri Google'ın ABD'deki sunucularında işlenir (Firebase için Google Analytics — standart Firebase projelerinde kullanıcı tarafından yapılandırılabilir bir bölge ayarı bulunmamaktadır).</span>
         </li>
         <li>
-          <strong>Firebase Cloud Functions — İletişim Formu (Google LLC, us-central1 – ABD):</strong>
+          <strong>Firebase Cloud Functions — İletişim Formu (Google LLC, europe-west1 – Belçika, AB):</strong>
           <br>
-          <span>dipnot.app web sitesindeki iletişim formu aracılığıyla gönderdiğiniz ad, e-posta, konu ve mesaj bilgileri Firebase Cloud Functions üzerinden işlenir ve yönetim paneli tarafından okunmak üzere Firestore'da (<code>contactSubmissions</code> koleksiyonu) saklanır. Kötüye kullanım incelemesi ve spam önleme amacıyla IP adresiniz ve tarayıcı bilgileriniz (user-agent) otomatik olarak kaydedilir. Bu aktarım KVKK'nın 9. maddesi kapsamında açık rızanıza dayanılarak gerçekleştirilir.</span>
+          <span>dipnot.app web sitesindeki iletişim formu aracılığıyla gönderdiğiniz ad, e-posta, konu ve mesaj bilgileri Firebase Cloud Functions üzerinden işlenir ve yönetim paneli tarafından okunmak üzere Firestore'da (<code>contactSubmissions</code> koleksiyonu) saklanır. Kötüye kullanım incelemesi ve spam önleme amacıyla IP adresiniz ve tarayıcı bilgileriniz (user-agent) otomatik olarak kaydedilir. Verileriniz Avrupa'daki sunucularda (Belçika, europe-west1) işlenmektedir.</span>
         </li>
       </ul>
       <p>Yurt dışına aktarım söz konusu olduğunda, KVKK'nın 9. maddesi uyarınca yeterli korumanın bulunduğu ülkelere (örneğin, AB ülkeleri) veya veri sorumlusunun yeterli korumayı yazılı olarak taahhüt ettiği hizmet sağlayıcılara aktarım yapılmaktadır. ABD'de yerleşik sağlayıcılara (Expo dahil) yapılan aktarımlar, açık rızanız alınarak veya KVKK md. 9 uyarınca gerekli güvenceler sağlanarak yapılır.</p>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -33,7 +33,7 @@ og:
   <section class="section">
     <div class="content">
       <h1>Privacy Policy (KVKK)</h1>
-      <p><strong>Last updated:</strong> <time datetime="2026-04-21">21 April 2026</time></p>
+      <p><strong>Last updated:</strong> <time datetime="2026-04-24">24 April 2026</time></p>
 
       <div class="notification is-warning">
         <p><strong>Note:</strong> This English version is provided for convenience. The Turkish version, <a href="/gizlilik-politikasi.html">Gizlilik Politikası ve Aydınlatma Metni</a>, is authoritative under Turkish law (KVKK) in case of any conflict.</p>
@@ -104,9 +104,9 @@ og:
           <span>Used to analyse in-app usage statistics, understand user behaviour, and improve the experience. Data collected includes device identifiers, session durations, screen views, and in-app interaction events. We do not share this data with marketing or third-party ad networks. Analytics data is processed on Google's servers in the USA (Google Analytics for Firebase — standard Firebase projects have no user-configurable region setting).</span>
         </li>
         <li>
-          <strong>Firebase Cloud Functions — Contact form (Google LLC, us-central1 – USA):</strong>
+          <strong>Firebase Cloud Functions — Contact form (Google LLC, europe-west1 – Belgium, EU):</strong>
           <br>
-          <span>The name, email, subject, and message you submit through the contact form on dipnot.app are processed by Firebase Cloud Functions and stored in Firestore (<code>contactSubmissions</code> collection) to be read by the admin panel. Your IP address and browser information (user-agent) are automatically recorded for abuse investigation and spam prevention. This transfer is carried out based on your explicit consent under KVKK article 9.</span>
+          <span>The name, email, subject, and message you submit through the contact form on dipnot.app are processed by Firebase Cloud Functions and stored in Firestore (<code>contactSubmissions</code> collection) to be read by the admin panel. Your IP address and browser information (user-agent) are automatically recorded for abuse investigation and spam prevention. Your data is processed on servers in Europe (Belgium, europe-west1).</span>
         </li>
       </ul>
       <p>Where cross-border transfer is involved, transfers are made under KVKK article 9 to countries with adequate protection (e.g. EU countries) or to service providers that have committed in writing to provide adequate protection. Transfers to US-based providers (including Expo) are carried out with your explicit consent or under the safeguards required by KVKK article 9.</p>


### PR DESCRIPTION
## Summary

Closes the [`core_docs` 2026-04-21 Phase D ask](https://github.com/Dipnot-App/core_docs/blob/main/communication/to-landing.md). Regenerates the Firebase Cloud Functions (contact form) entry in both the Turkish authoritative ([`gizlilik-politikasi.html`](../blob/chore/phase-d-privacy-policy-europe-west1/gizlilik-politikasi.html)) and the English mirror ([`privacy-policy.html`](../blob/chore/phase-d-privacy-policy-europe-west1/privacy-policy.html)) from the updated registry in [`core_docs/data-processors.md`](https://github.com/Dipnot-App/core_docs/blob/main/data-processors.md).

Publishing now (rather than waiting for Phase C to close) per the ask's explicit early-publish carve-out: *"If you'd rather publish the regen sooner (few enough users that the lead is low-risk), that's a call you can make."* Dipnot is pre-launch — user exposure is effectively zero.

## Diff

- Provider header: `us-central1 – ABD / USA` → `europe-west1 – Belçika, AB / Belgium, EU`.
- Final sentence swapped from the KVKK art. 9 cross-border framing to an EU-locality statement. Processing is now inside EU/EEA, matching the `eur3` Firebase entry pattern — the art. 9 clause no longer applies to this specific processor (Expo + GA for Firebase are still US-based, so the general §3 clause stays untouched).
- `Son Güncelleme` / `Last updated` bumped to 2026-04-24 in both files.
- CHANGELOG entry added.

## Sync state

- Live `js/newsletter.js` + `js/contact.js` already serve `europe-west1` (PR #66, deployed 2026-04-24).
- This PR brings the user-visible policy text in sync with the infrastructure.
- Phase C (functions-side `us-central1` retirement) runs independently; this regen doesn't depend on it.

## Follow-up (separate ask, not in this PR)

Per [`core_docs/CLAUDE.md`](https://github.com/Dipnot-App/core_docs/blob/main/CLAUDE.md) privacy-policy sync step 5, a line should be added to `data-processors.md`'s changelog noting the landing-side regen. That's a `core_docs` edit outside my commit boundary — writing an ack + ask into [`to-core-docs.md`](https://github.com/Dipnot-App/core_docs/blob/main/communication/to-core-docs.md) on merge.

## Test plan

- [ ] `npm run build && npm run check:html` stays green (verified locally — clean)
- [ ] Local preview — TR + EN pages render the new snippet; `<time datetime="2026-04-24">` renders in body
- [ ] Both files stay in structural lockstep (same numbered sections, same bullet count)
- [ ] `grep us-central1` on the repo returns zero matches in HTML