### PR TITLE
Tweak, equal-height cards in features + how-it-works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ terse — the commit message and PR body carry the full reasoning.
 
 ## 2026-04-24
 
+- **Design** — Equal-height cards in `#features` and `#how-it-works`
+  on [`index.html`](index.html). Bulma columns stretch to row height
+  by default, but `.card` stays at content height — so varying text
+  lengths produced uneven card rows. Added a small rule in
+  [`css/styles.css`](css/styles.css) making each card `flex: 1`
+  inside its flex column. Bumped `cssVersion` for cache-bust.
 - **Privacy (Phase D)** — Regenerated the Firebase Cloud Functions
   (contact form) entry in [`gizlilik-politikasi.html`](gizlilik-politikasi.html)
   and [`privacy-policy.html`](privacy-policy.html) to reflect the

--- a/_data/site.json
+++ b/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
-  "cssVersion": "260421_1",
+  "cssVersion": "260424_1",
   "jsVersion": "260424_1",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",

--- a/css/styles.css
+++ b/css/styles.css
@@ -34,11 +34,24 @@ h1, h2, h3, h4, h5, h6,
   background-image: linear-gradient(92deg, #37525E 20%, #89A3B3 100%);
 }
 
-.menu-list li:hover a, 
+.menu-list li:hover a,
 #features .card:hover .icon,
 #faq .card:hover .card-header,
 #faq .card:hover .card-header-title {
   color: var(--color-primary);
+}
+
+/* Bulma's .columns stretches each column to row height, but .card is a
+   block element that only grows to its own content — so varying text
+   lengths produce uneven card rows. Stretch the card to fill its column. */
+#features .column,
+#how-it-works .column {
+  display: flex;
+}
+
+#features .card,
+#how-it-works .card {
+  flex: 1;
 }
 
 .menu-list li:hover {


### PR DESCRIPTION
## Summary

The cards in `#features` (4-up) and `#how-it-works` (3-up) on [`index.html`](../blob/chore/equal-height-feature-and-hiw-cards/index.html) had visibly uneven heights because text lengths vary across cards. Bulma's `.columns` stretches columns to the row's tallest, but `.card` stays at content height — so the longer description made its card taller while the shorter ones left empty space.

## Fix

Two small rules in [`css/styles.css`](../blob/chore/equal-height-feature-and-hiw-cards/css/styles.css), scoped by section ID so the rule doesn't leak into `#faq` or future card usage:

```css
#features .column,
#how-it-works .column {
  display: flex;
}

#features .card,
#how-it-works .card {
  flex: 1;
}
```

The column is already a flex item in `.columns` (stretches vertically by default). Making it a flex container lets the card inside grow to fill the column. `flex: 1` = `flex-grow:1; flex-shrink:1; flex-basis:0`.

## Not changed

- `#faq` cards — they're a collapsible accordion; variable height there is intentional.
- Desktop column widths (`is-3` for features, default for how-it-works) — unchanged.
- Mobile stacking — columns stack on narrow viewports so there's no row to align against; `flex: 1` on a single item is a no-op.

## Test plan

- [ ] `npm run serve` — verify features cards are all same height on desktop (≥1024px) and stack normally on mobile
- [ ] Verify how-it-works cards (with the long step-3 caption) are same height on desktop
- [ ] Verify FAQ accordion still collapses normally (not scoped, shouldn't be affected)
- [ ] Build + html-validate stay green (confirmed locally)

Bumps `cssVersion` to `260424_1` for cache-bust.