### PR TITLE
Add, Prettier + audit script (code-quality gaps)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+_site
+node_modules
+package-lock.json
+
+# Local per-machine Claude Code settings (globally gitignored).
+.claude/
+
+# Nunjucks templates — Prettier has no built-in parser; leave to manual formatting.
+*.njk
+
+# XML / plain-text / binary assets Prettier shouldn't touch.
+sitemap.xml
+*.svg
+img/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: reverse chronological, one heading per date (`## YYYY-MM-DD`),
 one bullet per change with a PR link when available. Keep entries
 terse — the commit message and PR body carry the full reasoning.
 
+## 2026-04-25
+
+- **Tooling** — Added Prettier (`^3.8.3`) plus `format`, `format:check`,
+  and `audit` scripts in [`package.json`](package.json), a minimal
+  [`.prettierrc.json`](.prettierrc.json) (mirrors admin's config minus
+  the Tailwind plugin), and a [`.prettierignore`](.prettierignore)
+  covering `_site/`, `node_modules`, `package-lock.json`, `.claude/`,
+  `*.njk` (Nunjucks — no built-in Prettier parser), `sitemap.xml`,
+  `*.svg`, and `img/`. Closes the first half of the `core_docs`
+  2026-04-24 code-quality-gaps ask (formatter + audit script);
+  Dependabot was already wired via
+  [`.github/dependabot.yml`](.github/dependabot.yml). No repo-wide
+  reformat yet — `format:check` reports 13 pre-existing files; that
+  reformat ships as a separate PR for clean review.
+
 ## 2026-04-24
 
 - **Design** — Equal-height cards in `#features` and `#how-it-works`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "html-validate": "^10.13.1",
         "http-server": "^14.1.1",
         "pa11y-ci": "^4.1.0",
+        "prettier": "^3.8.3",
         "wait-on": "^9.0.5"
       }
     },
@@ -5319,6 +5320,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/progress": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "check:html": "html-validate \"_site/**/*.html\"",
     "check:a11y": "pa11y-ci --sitemap http://localhost:8080/sitemap.xml",
     "check:lighthouse": "lhci autorun",
-    "check:links": "lychee --no-progress _site"
+    "check:links": "lychee --no-progress _site",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "audit": "npm audit --audit-level=high"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",
@@ -18,6 +21,7 @@
     "html-validate": "^10.13.1",
     "http-server": "^14.1.1",
     "pa11y-ci": "^4.1.0",
+    "prettier": "^3.8.3",
     "wait-on": "^9.0.5"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Closes the **formatter** + **audit script** halves of the `core_docs` 2026-04-24 ask in [`communication/to-landing.md`](../../../core_docs/communication/to-landing.md). The Dependabot half was already live in [`.github/dependabot.yml`](.github/dependabot.yml).
- No repo-wide reformat yet — `format:check` flags 13 pre-existing files; that reformat ships separately for clean review.

## Details

- **[`package.json`](package.json)** — adds `prettier@^3.8.3` devDep, plus three scripts: `format` (`prettier --write .`), `format:check` (`prettier --check .`), `audit` (`npm audit --audit-level=high`).
- **[`.prettierrc.json`](.prettierrc.json)** — mirrors `admin_dipnot_app`'s config minus the Tailwind plugin: `semi: true`, `singleQuote: false`, `trailingComma: "all"`, `printWidth: 80`.
- **[`.prettierignore`](.prettierignore)** — `_site`, `node_modules`, `package-lock.json`, `.claude/` (local Claude Code settings), `*.njk` (Nunjucks — no built-in Prettier parser), `sitemap.xml`, `*.svg`, `img/`.
- **[`CHANGELOG.md`](CHANGELOG.md)** — 2026-04-25 entry.

## Known caveat — audit exits 1 today

`npm run audit` currently exits **1** due to the three accepted high-level dev-dep vulnerabilities documented in `CLAUDE.md`'s "Accepted dev-dep vulnerabilities" table (lodash `_.template` / `_.unset`, tmp symlink). All are unreachable with our inputs; upstream can't patch without breaking `pa11y-ci` / `@lhci/cli`. Flagged in the ack back to `core_docs` — may need to bump landing's audit-level to `critical` if session-start checks treat `audit: FAIL` as a gate.

## Test plan

- [ ] CI build + `check:html` / `check:a11y` / `check:lighthouse` / `check:links` still pass (no change to those paths).
- [ ] `npm run format:check` locally reports the 13 pre-existing unformatted files (expected — repo-wide reformat is a follow-up PR).
- [ ] `npm run audit` locally exits 1 with only the three CLAUDE.md-documented advisories (no new vulns introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)