### PR TITLE
Format, repo-wide prettier --write . (+ base.njk indent fix)

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,14 +8,22 @@ robots: "noindex"
 hideNav: true
 permalink: "/404.html"
 ---
+
 <!-- HERO BANNER -->
 <section class="hero is-fullheight-with-navbar has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column is-align-content-center">
-        <p class="title is-size-1 has-text-white has-text-centered mb-5"><span class="has-text-primary" style="font-size: 12rem;">404</span> <span style="white-space: nowrap;">Sayfa bulunamadı</span></p>
-        <p class="subtitle has-text-white has-text-centered">Üzgünüz, aradığınız sayfa bulunamadı.</p>
-        <div class="buttons are-large mt-6 is-flex is-justify-content-center mb-6">
+        <p class="title is-size-1 has-text-white has-text-centered mb-5">
+          <span class="has-text-primary" style="font-size: 12rem">404</span>
+          <span style="white-space: nowrap">Sayfa bulunamadı</span>
+        </p>
+        <p class="subtitle has-text-white has-text-centered">
+          Üzgünüz, aradığınız sayfa bulunamadı.
+        </p>
+        <div
+          class="buttons are-large mt-6 is-flex is-justify-content-center mb-6"
+        >
           <a href="/" class="button is-light is-outlined">
             <span class="ml-2">Anasayfaya dön</span>
           </a>
@@ -24,7 +32,7 @@ permalink: "/404.html"
 
       <div class="column is-align-content-center">
         <figure class="image">
-          <img src="/img/deviceframes-hero.png" alt="Hero DeviceFrames">
+          <img src="/img/deviceframes-hero.png" alt="Hero DeviceFrames" />
         </figure>
       </div>
     </div>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ terse — the commit message and PR body carry the full reasoning.
   [`.github/dependabot.yml`](.github/dependabot.yml). No repo-wide
   reformat yet — `format:check` reports 13 pre-existing files; that
   reformat ships as a separate PR for clean review.
+- **Formatting** — Repo-wide `prettier --write .` over the 13
+  previously-flagged files (4 HTML pages + 4 legal pages + 3 JS
+  files + `css/styles.css` + `CHANGELOG.md` + `site.webmanifest`).
+  Pure-whitespace + quote-style changes — no semantic diffs, save
+  two incidental fixes Prettier caught: a stray double-semicolon
+  in [`css/styles.css`](css/styles.css) (`rgba(…);;` → `rgba(…);`)
+  and a trailing-newline miss on the same file. Bumped
+  `cssVersion` and `jsVersion` to `260425_1` in
+  [`_data/site.json`](_data/site.json) to cache-bust.
+- **Layout fix** — Stripped the 2-space indent in front of
+  `{{ content | safe }}` in [`_includes/layouts/base.njk`](_includes/layouts/base.njk).
+  Prettier's YAML-frontmatter canonicalization inserts a blank
+  line after the closing `---`, which combined with the old indent
+  produced a rendered line with trailing whitespace (tripped
+  `html-validate`'s `no-trailing-whitespace` rule on every page).
+  Left-aligning the expression eliminates the issue; rendered
+  HTML whitespace is inconsequential.
 
 ## 2026-04-24
 
@@ -94,7 +111,7 @@ terse — the commit message and PR body carry the full reasoning.
   `npm run check:html` (30 → 0). Root causes: Nunjucks `{% if %}`
   conditional meta tags leaving trailing whitespace when a frontmatter
   key was unset (base.njk); Bulma's legacy `<a role="button"
-  class="navbar-burger">` (nav.njk → swapped to `<button>`);
+class="navbar-burger">` (nav.njk → swapped to `<button>`);
   `<th>` cells missing `scope` attributes in the KVKK personal-data
   processor tables (gizlilik-politikasi.html + privacy-policy.html).
   Contributes to epic [#32](https://github.com/Dipnot-App/www.dipnot.app/issues/32).

--- a/_data/site.json
+++ b/_data/site.json
@@ -1,8 +1,8 @@
 {
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
-  "cssVersion": "260424_1",
-  "jsVersion": "260424_1",
+  "cssVersion": "260425_1",
+  "jsVersion": "260425_1",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",
   "ogImage": "https://dipnot.app/android-chrome-512x512.png",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -61,7 +61,7 @@
   {% include "partials/nav.njk" %}
   {%- endif %}
 
-  {{ content | safe }}
+{{ content | safe }}
 
   {% include "partials/footer.njk" %}
 

--- a/brand-book.html
+++ b/brand-book.html
@@ -8,6 +8,7 @@ og:
   locale: tr_TR
   url: "https://dipnot.app/brand-book.html"
 ---
+
 <!-- HERO BANNER -->
 <section class="hero has-background-hero">
   <div class="hero-body">
@@ -21,62 +22,83 @@ og:
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-  <a href="https://app.gingersauce.co/my/view-new-v3/72228" target="_blank" rel="noopener noreferrer">Dipnot Brand Book by Gingersauce</a>
+  <a
+    href="https://app.gingersauce.co/my/view-new-v3/72228"
+    target="_blank"
+    rel="noopener noreferrer"
+    >Dipnot Brand Book by Gingersauce</a
+  >
 
   <!-- LOGO CONTENT -->
   <section class="section">
-
     <div class="content">
       <h2>Logo Versions</h2>
     </div>
 
     <div class="columns has-background-white">
+      <div class="column">
+        <div class="box has-background-white">
+          <figure class="has-text-centered p-6">
+            <img
+              src="/img/logos/logo.svg"
+              class="has-text-centered"
+              alt="Logo"
+              width="200"
+            />
+          </figure>
+        </div>
+      </div>
 
       <div class="column">
         <div class="box has-background-white">
           <figure class="has-text-centered p-6">
-            <img src="/img/logos/logo.svg" class="has-text-centered" alt="Logo" width="200">
+            <img
+              src="/img/logos/logo-gold.svg"
+              class="has-text-centered"
+              alt="Logo"
+              width="200"
+            />
           </figure>
         </div>
       </div>
 
       <div class="column">
-        <div class="box has-background-white">
-          <figure class="has-text-centered p-6">
-            <img src="/img/logos/logo-gold.svg" class="has-text-centered" alt="Logo" width="200">
-          </figure>
-        </div>
-      </div>
-
-      <div class="column">
-        <div class="box" style="background-color: #338596;">
+        <div class="box" style="background-color: #338596">
           <figure class="has-text-centered">
-            <img src="/img/logos/logo-white-on-teal.svg" class="has-text-centered" alt="Logo" width="280">
+            <img
+              src="/img/logos/logo-white-on-teal.svg"
+              class="has-text-centered"
+              alt="Logo"
+              width="280"
+            />
           </figure>
         </div>
       </div>
 
       <div class="column">
-        <div class="box" style="background-color: #131B26;">
+        <div class="box" style="background-color: #131b26">
           <figure class="has-text-centered">
-            <img src="/img/logos/logo-white-on-sky-captain.svg" class="has-text-centered" alt="Logo" width="280">
+            <img
+              src="/img/logos/logo-white-on-sky-captain.svg"
+              class="has-text-centered"
+              alt="Logo"
+              width="280"
+            />
           </figure>
         </div>
       </div>
-
     </div>
   </section>
 
   <!-- COLOR CONTENT -->
   <section class="section">
-
     <div class="content">
       <h2>Colors</h2>
     </div>
 
     <div class="columns">
       <div class="column">
-        <div class="box has-text-white" style="background-color: #348698;">
+        <div class="box has-text-white" style="background-color: #348698">
           <h3>Algiers Blue</h3>
           <p>Hex #348698</p>
           <p>RGB 52 134 152</p>
@@ -86,7 +108,7 @@ og:
       </div>
 
       <div class="column">
-        <div class="box has-text-white" style="background-color: #131B26;">
+        <div class="box has-text-white" style="background-color: #131b26">
           <h3>Sky Captain</h3>
           <p>Hex #131B26</p>
           <p>RGB 19 27 38</p>
@@ -96,7 +118,7 @@ og:
       </div>
 
       <div class="column">
-        <div class="box has-text-white" style="background-color: #2E162C;">
+        <div class="box has-text-white" style="background-color: #2e162c">
           <h3>Winter Bloom</h3>
           <p>Hex #2E162C</p>
           <p>RGB 46 22 44</p>
@@ -109,35 +131,28 @@ og:
 
   <!-- TYPOGRAFI CONTENT -->
   <section class="section">
-
     <div class="content">
       <h2>Typography</h2>
     </div>
 
     <div class="columns">
-
       <div class="column">
-        <div class="box has-text-centered" style="background-color: #131B26;">
+        <div class="box has-text-centered" style="background-color: #131b26">
           Primary Font
-          <br>
+          <br />
           Inter
-          <br>
+          <br />
           Aa
         </div>
       </div>
-
     </div>
   </section>
 
   <!-- RULES CONTENT -->
-  <section class="section">
-
-  </section>
+  <section class="section"></section>
 
   <!-- MISUSE CONTENT -->
-  <section class="section">
-
-  </section>
+  <section class="section"></section>
 
   <!-- Vision/Mission CONTENT -->
   <section class="section">
@@ -146,7 +161,10 @@ og:
         <div class="box">
           <div class="content">
             <div class="h3">Vision</div>
-            <p>To become the most trusted and enduring source of knowledge for the underwater world.</p>
+            <p>
+              To become the most trusted and enduring source of knowledge for
+              the underwater world.
+            </p>
           </div>
         </div>
       </div>
@@ -155,7 +173,10 @@ og:
         <div class="box">
           <div class="content">
             <div class="h3">Mission</div>
-            <p>To deliver clear, reliable, and well-crafted content about diving and the underwater world, accessible to all levels.</p>
+            <p>
+              To deliver clear, reliable, and well-crafted content about diving
+              and the underwater world, accessible to all levels.
+            </p>
           </div>
         </div>
       </div>
@@ -163,8 +184,5 @@ og:
   </section>
 
   <!-- Brand Archetype CONTENT -->
-  <section class="section">
-
-  </section>
-
+  <section class="section"></section>
 </main>

--- a/css/styles.css
+++ b/css/styles.css
@@ -4,15 +4,34 @@
 }
 
 body,
-h1, h2, h3, h4, h5, h6,
-.title, .subtitle {
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.title,
+.subtitle {
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 /* Type-scale helpers for tokens Bulma doesn't cover (caption 12 / small 14 / lead 18) */
-.text-caption { font-size: 12px; line-height: 1.5; }
-.text-small   { font-size: 14px; line-height: 1.5; }
-.text-lead    { font-size: 18px; line-height: 1.5; }
+.text-caption {
+  font-size: 12px;
+  line-height: 1.5;
+}
+.text-small {
+  font-size: 14px;
+  line-height: 1.5;
+}
+.text-lead {
+  font-size: 18px;
+  line-height: 1.5;
+}
 
 .navbar.is-fixed-top {
   box-shadow: 0 0 10px black;
@@ -31,7 +50,7 @@ h1, h2, h3, h4, h5, h6,
 }
 
 .has-background-hero {
-  background-image: linear-gradient(92deg, #37525E 20%, #89A3B3 100%);
+  background-image: linear-gradient(92deg, #37525e 20%, #89a3b3 100%);
 }
 
 .menu-list li:hover a,
@@ -55,7 +74,7 @@ h1, h2, h3, h4, h5, h6,
 }
 
 .menu-list li:hover {
-  background-color: rgba(255, 255, 255, 0.05);;
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 @media screen and (max-width: 1023px) {

--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -15,12 +15,17 @@ og:
   url: "https://dipnot.app/gizlilik-politikasi.html"
   description: "Dipnot Gizlilik Politikası ve Aydınlatma Metni (KVKK)."
 ---
+
 <!-- HERO BANNER -->
 <section class="hero has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column">
-        <p class="title is-size-1 has-text-white mb-5">Gizlilik Politikası ve <span class="has-text-primary">Aydınlatma Metni</span> <span style="white-space: nowrap;">(KVKK)</span></p>
+        <p class="title is-size-1 has-text-white mb-5">
+          Gizlilik Politikası ve
+          <span class="has-text-primary">Aydınlatma Metni</span>
+          <span style="white-space: nowrap">(KVKK)</span>
+        </p>
       </div>
     </div>
   </div>
@@ -28,22 +33,31 @@ og:
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-
   <!-- CONTENT -->
   <section class="section">
     <div class="content">
       <h1>Gizlilik Politikası ve Aydınlatma Metni (KVKK)</h1>
-      <p><strong>Son Güncelleme:</strong> <time datetime="2026-04-24">24 Nisan 2026</time></p>
+      <p>
+        <strong>Son Güncelleme:</strong>
+        <time datetime="2026-04-24">24 Nisan 2026</time>
+      </p>
 
       <h2>1. Veri Sorumlusu ve Temsilcisi</h2>
-      <p>6698 sayılı Kişisel Verilerin Korunması Kanunu ("KVKK") uyarınca, kişisel verileriniz "Dipnot" uygulamasını yöneten ekip tarafından veri sorumlusu sıfatıyla aşağıda açıklanan kapsamda işlenecektir.</p>
+      <p>
+        6698 sayılı Kişisel Verilerin Korunması Kanunu ("KVKK") uyarınca,
+        kişisel verileriniz "Dipnot" uygulamasını yöneten ekip tarafından veri
+        sorumlusu sıfatıyla aşağıda açıklanan kapsamda işlenecektir.
+      </p>
       <ul>
         <li>Veri Sorumlusu: Dipnot Uygulama Ekibi</li>
         <li>İletişim E-postası: help@dipnot.app</li>
       </ul>
 
       <h2>2. Toplanan Kişisel Veriler, İşleme Amaçları ve Hukuki Sebepler</h2>
-      <p>Dipnot uygulamasına kaydolduğunuzda ve uygulamayı kullandığınızda aşağıdaki verileriniz işlenmektedir:</p>
+      <p>
+        Dipnot uygulamasına kaydolduğunuzda ve uygulamayı kullandığınızda
+        aşağıdaki verileriniz işlenmektedir:
+      </p>
       <table class="table">
         <thead>
           <tr>
@@ -57,24 +71,34 @@ og:
           <tr>
             <th scope="row">Kimlik Bilgisi</th>
             <td>Ad, Soyad</td>
-            <td>Hesap oluşturma, kullanıcıları tanımlama, profilleri kişiselleştirme</td>
+            <td>
+              Hesap oluşturma, kullanıcıları tanımlama, profilleri
+              kişiselleştirme
+            </td>
             <td>Açık rıza</td>
           </tr>
           <tr>
             <th scope="row">İletişim Bilgisi</th>
             <td>E-posta adresi, Telefon numarası</td>
-            <td>Hesap doğrulama (e-posta doğrulama), şifre yenileme, bildirim gönderme, kullanıcı ile iletişim</td>
+            <td>
+              Hesap doğrulama (e-posta doğrulama), şifre yenileme, bildirim
+              gönderme, kullanıcı ile iletişim
+            </td>
             <td>Açık rıza</td>
           </tr>
           <tr>
             <th scope="row">Kullanım Verileri</th>
-            <td>Okunan makaleler, beğeniler, kaydedilen içerikler, oturum süreleri</td>
+            <td>
+              Okunan makaleler, beğeniler, kaydedilen içerikler, oturum süreleri
+            </td>
             <td>İçerik önerileri sunma, deneyimi iyileştirme, trend analizi</td>
             <td>Meşru menfaat</td>
           </tr>
           <tr>
             <th scope="row">Teknik Veriler</th>
-            <td>Cihaz modeli, işletim sistemi sürümü, IP adresi, uygulama sürümü</td>
+            <td>
+              Cihaz modeli, işletim sistemi sürümü, IP adresi, uygulama sürümü
+            </td>
             <td>Uygulamanın çalışmasını sağlama, hata ayıklama, güvenlik</td>
             <td>Meşru menfaat</td>
           </tr>
@@ -82,65 +106,161 @@ og:
       </table>
 
       <h2>3. Verilerin Aktarıldığı Üçüncü Taraflar ve Yurt Dışına Aktarım</h2>
-      <p>Toplanan kişisel verileriniz, aşağıdaki hizmet sağlayıcılarla sınırlı olmak üzere üçüncü taraflarla paylaşılabilir:</p>
+      <p>
+        Toplanan kişisel verileriniz, aşağıdaki hizmet sağlayıcılarla sınırlı
+        olmak üzere üçüncü taraflarla paylaşılabilir:
+      </p>
       <ul>
         <li>
-          <strong>Google Firebase ve Google Cloud Platform (eur3 – Avrupa):</strong>
-          <br>
-          <span>Kimlik doğrulama, veritabanı (Firestore), dosya depolama (Storage) ve push bildirimleri için. Verileriniz Avrupa'daki sunucularda (Frankfurt, eur3) barındırılmaktadır.</span>
+          <strong
+            >Google Firebase ve Google Cloud Platform (eur3 – Avrupa):</strong
+          >
+          <br />
+          <span
+            >Kimlik doğrulama, veritabanı (Firestore), dosya depolama (Storage)
+            ve push bildirimleri için. Verileriniz Avrupa'daki sunucularda
+            (Frankfurt, eur3) barındırılmaktadır.</span
+          >
         </li>
         <li>
           <strong>Expo (Expo Application Services, Inc. – ABD):</strong>
-          <br>
-          <span>Dipnot mobil uygulaması Expo / React Native altyapısıyla geliştirilmiştir. Push bildirim tokenlarınız Expo Push servisi üzerinden işlenir ve bildirim gönderiminde kullanılır. Uygulama kararlılığını ölçmek ve hata ayıklamak amacıyla sınırlı cihaz ve çalışma zamanı bilgileri (cihaz modeli, işletim sistemi sürümü, uygulama sürümü) Expo'nun ABD'deki sunucularına iletilebilir. Ayrıca uygulama her açılışında Expo sunucularına (<code>u.expo.dev</code>) hafif bir sorgu göndererek yeni bir JavaScript/varlık güncellemesi olup olmadığını kontrol eder (OTA — "over-the-air" güncelleme); bu sorguda uygulama kimliği, çalışma zamanı sürümü ve güncelleme kanalı bilgisi yer alır. Bu aktarımlar KVKK'nın 9. maddesi kapsamında açık rızanıza dayanılarak gerçekleştirilir.</span>
+          <br />
+          <span
+            >Dipnot mobil uygulaması Expo / React Native altyapısıyla
+            geliştirilmiştir. Push bildirim tokenlarınız Expo Push servisi
+            üzerinden işlenir ve bildirim gönderiminde kullanılır. Uygulama
+            kararlılığını ölçmek ve hata ayıklamak amacıyla sınırlı cihaz ve
+            çalışma zamanı bilgileri (cihaz modeli, işletim sistemi sürümü,
+            uygulama sürümü) Expo'nun ABD'deki sunucularına iletilebilir. Ayrıca
+            uygulama her açılışında Expo sunucularına (<code>u.expo.dev</code>)
+            hafif bir sorgu göndererek yeni bir JavaScript/varlık güncellemesi
+            olup olmadığını kontrol eder (OTA — "over-the-air" güncelleme); bu
+            sorguda uygulama kimliği, çalışma zamanı sürümü ve güncelleme kanalı
+            bilgisi yer alır. Bu aktarımlar KVKK'nın 9. maddesi kapsamında açık
+            rızanıza dayanılarak gerçekleştirilir.</span
+          >
         </li>
         <li>
           <strong>Google Analytics (Firebase için Google Analytics):</strong>
-          <br>
-          <span>Mobil uygulamadaki kullanım istatistiklerini analiz etmek, kullanıcı davranışlarını anlamak ve deneyimi iyileştirmek amacıyla. Toplanan veriler arasında cihaz tanımlayıcıları, oturum süreleri, ekran görüntülemeleri ve uygulama içi etkileşim olayları yer alır. Bu verileri pazarlama veya üçüncü taraf reklam ağlarıyla paylaşmıyoruz. Analytics verileri Google'ın ABD'deki sunucularında işlenir (Firebase için Google Analytics — standart Firebase projelerinde kullanıcı tarafından yapılandırılabilir bir bölge ayarı bulunmamaktadır).</span>
+          <br />
+          <span
+            >Mobil uygulamadaki kullanım istatistiklerini analiz etmek,
+            kullanıcı davranışlarını anlamak ve deneyimi iyileştirmek amacıyla.
+            Toplanan veriler arasında cihaz tanımlayıcıları, oturum süreleri,
+            ekran görüntülemeleri ve uygulama içi etkileşim olayları yer alır.
+            Bu verileri pazarlama veya üçüncü taraf reklam ağlarıyla
+            paylaşmıyoruz. Analytics verileri Google'ın ABD'deki sunucularında
+            işlenir (Firebase için Google Analytics — standart Firebase
+            projelerinde kullanıcı tarafından yapılandırılabilir bir bölge ayarı
+            bulunmamaktadır).</span
+          >
         </li>
         <li>
-          <strong>Firebase Cloud Functions — İletişim Formu (Google LLC, europe-west1 – Belçika, AB):</strong>
-          <br>
-          <span>dipnot.app web sitesindeki iletişim formu aracılığıyla gönderdiğiniz ad, e-posta, konu ve mesaj bilgileri Firebase Cloud Functions üzerinden işlenir ve yönetim paneli tarafından okunmak üzere Firestore'da (<code>contactSubmissions</code> koleksiyonu) saklanır. Kötüye kullanım incelemesi ve spam önleme amacıyla IP adresiniz ve tarayıcı bilgileriniz (user-agent) otomatik olarak kaydedilir. Verileriniz Avrupa'daki sunucularda (Belçika, europe-west1) işlenmektedir.</span>
+          <strong
+            >Firebase Cloud Functions — İletişim Formu (Google LLC, europe-west1
+            – Belçika, AB):</strong
+          >
+          <br />
+          <span
+            >dipnot.app web sitesindeki iletişim formu aracılığıyla
+            gönderdiğiniz ad, e-posta, konu ve mesaj bilgileri Firebase Cloud
+            Functions üzerinden işlenir ve yönetim paneli tarafından okunmak
+            üzere Firestore'da (<code>contactSubmissions</code> koleksiyonu)
+            saklanır. Kötüye kullanım incelemesi ve spam önleme amacıyla IP
+            adresiniz ve tarayıcı bilgileriniz (user-agent) otomatik olarak
+            kaydedilir. Verileriniz Avrupa'daki sunucularda (Belçika,
+            europe-west1) işlenmektedir.</span
+          >
         </li>
       </ul>
-      <p>Yurt dışına aktarım söz konusu olduğunda, KVKK'nın 9. maddesi uyarınca yeterli korumanın bulunduğu ülkelere (örneğin, AB ülkeleri) veya veri sorumlusunun yeterli korumayı yazılı olarak taahhüt ettiği hizmet sağlayıcılara aktarım yapılmaktadır. ABD'de yerleşik sağlayıcılara (Expo dahil) yapılan aktarımlar, açık rızanız alınarak veya KVKK md. 9 uyarınca gerekli güvenceler sağlanarak yapılır.</p>
+      <p>
+        Yurt dışına aktarım söz konusu olduğunda, KVKK'nın 9. maddesi uyarınca
+        yeterli korumanın bulunduğu ülkelere (örneğin, AB ülkeleri) veya veri
+        sorumlusunun yeterli korumayı yazılı olarak taahhüt ettiği hizmet
+        sağlayıcılara aktarım yapılmaktadır. ABD'de yerleşik sağlayıcılara (Expo
+        dahil) yapılan aktarımlar, açık rızanız alınarak veya KVKK md. 9
+        uyarınca gerekli güvenceler sağlanarak yapılır.
+      </p>
 
       <h2>4. Veri Toplama Yöntemi ve Hukuki Sebep</h2>
-      <p>Kişisel verileriniz, Dipnot uygulamasına kayıt formu doldurulduğunda, uygulama içi etkileşimler sırasında ve teknik verilerin otomatik olarak toplanması yoluyla elde edilmektedir. Veri işleme faaliyetlerimiz, KVKK'nın 5. maddesinde belirtilen aşağıdaki hukuki sebeplere dayanır:</p>
+      <p>
+        Kişisel verileriniz, Dipnot uygulamasına kayıt formu doldurulduğunda,
+        uygulama içi etkileşimler sırasında ve teknik verilerin otomatik olarak
+        toplanması yoluyla elde edilmektedir. Veri işleme faaliyetlerimiz,
+        KVKK'nın 5. maddesinde belirtilen aşağıdaki hukuki sebeplere dayanır:
+      </p>
       <ul>
         <li>Açık rıza (kimlik ve iletişim bilgileri için)</li>
         <li>Meşru menfaat (kullanım ve teknik verilerin analiz edilmesi)</li>
       </ul>
 
       <h2>5. Veri Saklama Süresi</h2>
-      <p>Kişisel verileriniz, işleme amaçlarının gerektirdiği süre boyunca saklanır. Bu süre, hesabınızın aktif olduğu süredir. Hesabınızı sildiğinizde veya silinmesini talep ettiğinizde, verileriniz en geç 30 gün içinde anonim hale getirilir veya silinir. Yasal yükümlülükler gereği (örneğin, ticari iletişim kayıtları) saklanması gereken veriler, ilgili mevzuatta belirtilen süreler boyunca muhafaza edilir.</p>
+      <p>
+        Kişisel verileriniz, işleme amaçlarının gerektirdiği süre boyunca
+        saklanır. Bu süre, hesabınızın aktif olduğu süredir. Hesabınızı
+        sildiğinizde veya silinmesini talep ettiğinizde, verileriniz en geç 30
+        gün içinde anonim hale getirilir veya silinir. Yasal yükümlülükler
+        gereği (örneğin, ticari iletişim kayıtları) saklanması gereken veriler,
+        ilgili mevzuatta belirtilen süreler boyunca muhafaza edilir.
+      </p>
 
       <h2>6. Veri Sahibinin Hakları (KVKK md. 11)</h2>
       <p>KVKK'nın 11. maddesi uyarınca aşağıdaki haklara sahipsiniz:</p>
       <ul>
         <li>Kişisel verilerinizin işlenip işlenmediğini öğrenme</li>
         <li>İşlenmişse buna ilişkin bilgi talep etme</li>
-        <li>İşleme amacını ve amacına uygun kullanılıp kullanılmadığını öğrenme</li>
+        <li>
+          İşleme amacını ve amacına uygun kullanılıp kullanılmadığını öğrenme
+        </li>
         <li>Yurt içinde veya yurt dışında aktarıldığı üçüncü kişileri bilme</li>
         <li>Eksik veya yanlış işlenmişse düzeltilmesini isteme</li>
-        <li>KVKK'nın 7. maddesinde öngörülen şartlar çerçevesinde silinmesini veya yok edilmesini isteme</li>
-        <li>Aktarılan üçüncü kişilere yukarıdaki düzeltme ve silme işlemlerinin bildirilmesini talep etme</li>
-        <li>İşlenen verilerin münhasıran otomatik sistemlerle analiz edilmesi nedeniyle aleyhinize bir sonucun ortaya çıkması durumunda buna itiraz etme</li>
-        <li>Kanuna aykırı işleme nedeniyle zarara uğramanız hâlinde zararın giderilmesini talep etme</li>
+        <li>
+          KVKK'nın 7. maddesinde öngörülen şartlar çerçevesinde silinmesini veya
+          yok edilmesini isteme
+        </li>
+        <li>
+          Aktarılan üçüncü kişilere yukarıdaki düzeltme ve silme işlemlerinin
+          bildirilmesini talep etme
+        </li>
+        <li>
+          İşlenen verilerin münhasıran otomatik sistemlerle analiz edilmesi
+          nedeniyle aleyhinize bir sonucun ortaya çıkması durumunda buna itiraz
+          etme
+        </li>
+        <li>
+          Kanuna aykırı işleme nedeniyle zarara uğramanız hâlinde zararın
+          giderilmesini talep etme
+        </li>
       </ul>
-      <p>Bu haklarınızı kullanmak için help@dipnot.app adresine kimlik tespiti sağlayacak bilgilerle başvuruda bulunabilirsiniz. Başvurularınız en kısa sürede (en geç 30 gün içinde) ücretsiz olarak cevaplandırılacaktır.</p>
+      <p>
+        Bu haklarınızı kullanmak için help@dipnot.app adresine kimlik tespiti
+        sağlayacak bilgilerle başvuruda bulunabilirsiniz. Başvurularınız en kısa
+        sürede (en geç 30 gün içinde) ücretsiz olarak cevaplandırılacaktır.
+      </p>
 
       <h2>7. Reklam ve Pazarlama E-postaları</h2>
-      <p>Şu an için Dipnot, herhangi bir reklam ağı (AdMob vb.) kullanmamaktadır. Gelecekte, ürün güncellemeleri, yeni özellikler veya özel teklifler hakkında bilgilendirme e-postası göndermek istememiz durumunda, size ayrıca açık rıza sorulacaktır. Bu rızayı kayıt sırasında veya ayarlar ekranından verebilir, istediğiniz zaman geri alabilirsiniz.</p>
+      <p>
+        Şu an için Dipnot, herhangi bir reklam ağı (AdMob vb.) kullanmamaktadır.
+        Gelecekte, ürün güncellemeleri, yeni özellikler veya özel teklifler
+        hakkında bilgilendirme e-postası göndermek istememiz durumunda, size
+        ayrıca açık rıza sorulacaktır. Bu rızayı kayıt sırasında veya ayarlar
+        ekranından verebilir, istediğiniz zaman geri alabilirsiniz.
+      </p>
 
       <h2>8. Çocuklara İlişkin Veriler</h2>
-      <p>Dipnot, 18 yaşından küçük bireylerin kişisel verilerini bilerek veya kasıtlı olarak toplamaz. Ebeveyn kontrolü olmadan çocukların uygulamayı kullanması önerilmez.</p>
+      <p>
+        Dipnot, 18 yaşından küçük bireylerin kişisel verilerini bilerek veya
+        kasıtlı olarak toplamaz. Ebeveyn kontrolü olmadan çocukların uygulamayı
+        kullanması önerilmez.
+      </p>
 
       <h2>9. Değişiklikler</h2>
-      <p>Bu Gizlilik Politikası gerektiğinde güncellenebilir. Önemli değişiklikler uygulama içi bildirim veya e-posta yoluyla duyurulacaktır. Değişikliklerin yürürlüğe girmesinin ardından uygulamayı kullanmaya devam etmeniz, güncellenmiş politikayı kabul ettiğiniz anlamına gelir.</p>
+      <p>
+        Bu Gizlilik Politikası gerektiğinde güncellenebilir. Önemli
+        değişiklikler uygulama içi bildirim veya e-posta yoluyla duyurulacaktır.
+        Değişikliklerin yürürlüğe girmesinin ardından uygulamayı kullanmaya
+        devam etmeniz, güncellenmiş politikayı kabul ettiğiniz anlamına gelir.
+      </p>
     </div>
   </section>
-
 </main>

--- a/index.html
+++ b/index.html
@@ -10,20 +10,29 @@ og:
   description: "Dipnot, dalış ve su altı dünyasına ilgi duyanlar için hazırlanmış makale odaklı bir mobil içerik platformudur."
 hasContactForm: true
 ---
+
 <!-- HERO BANNER -->
 <section class="hero is-fullheight-with-navbar has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column is-align-content-center">
-        <h1 class="title is-size-1 has-text-white mb-5">Su altını <span class="has-text-primary">okumaya</span> <span style="white-space: nowrap;">hazır mısınız?</span></h1>
-        <p class="subtitle has-text-white">Etkinliklerden teknolojiye, güvenlikten ekipmanlara dalış dünyasını derinlemesine ele alan içerikler...</p>
-        <div class="buttons are-large mt-6 is-flex is-justify-content-center mb-6">
+        <h1 class="title is-size-1 has-text-white mb-5">
+          Su altını <span class="has-text-primary">okumaya</span>
+          <span style="white-space: nowrap">hazır mısınız?</span>
+        </h1>
+        <p class="subtitle has-text-white">
+          Etkinliklerden teknolojiye, güvenlikten ekipmanlara dalış dünyasını
+          derinlemesine ele alan içerikler...
+        </p>
+        <div
+          class="buttons are-large mt-6 is-flex is-justify-content-center mb-6"
+        >
           <button type="button" class="button is-light is-outlined is-rounded">
-            <img src="/img/svg/google-play.svg" alt="Google Play">
+            <img src="/img/svg/google-play.svg" alt="Google Play" />
             <span class="ml-2">Google Play</span>
           </button>
           <button type="button" class="button is-light is-rounded">
-            <img src="/img/svg/app-store.svg" alt="App Store">
+            <img src="/img/svg/app-store.svg" alt="App Store" />
             <span class="ml-2">App Store</span>
           </button>
         </div>
@@ -31,7 +40,7 @@ hasContactForm: true
 
       <div class="column is-align-content-center">
         <figure class="image">
-          <img src="/img/deviceframes-hero.png" alt="Hero DeviceFrames">
+          <img src="/img/deviceframes-hero.png" alt="Hero DeviceFrames" />
         </figure>
       </div>
     </div>
@@ -40,23 +49,41 @@ hasContactForm: true
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-
   <!-- ABOUT APP -->
   <section id="about" class="section mt-6">
-    <div class="card" style="border-radius: 0 4em 0 4em;">
+    <div class="card" style="border-radius: 0 4em 0 4em">
       <div class="card-content p-0">
         <div class="columns is-gapless">
           <div class="column is-5 py-0">
             <figure class="image">
-              <img src="/img/about.webp" alt="About DeviceFrames" style="margin-top: -36px;">
+              <img
+                src="/img/about.webp"
+                alt="About DeviceFrames"
+                style="margin-top: -36px"
+              />
             </figure>
           </div>
 
           <div class="column is-7 is-flex is-justify-content-center">
-            <div class="is-align-content-center px-6 py-5" style="max-width: 600px;">
-              <h2 class="title is-2 mb-4"><span class="has-text-primary">Dipnot</span> nedir?</h2>
-              <p class="mt-3">Dipnot, dalış ve su altı dünyasına ilgi duyan herkes için hazırlanmış bağımsız bir içerik platformudur. Uygulama içinde; dalış kültürü, güvenlik, ekipman, çevre, tarih ve güncel konular üzerine özenle yazılmış makalelere ulaşabilirsiniz.</p>
-              <p class="mt-3">Dipnot, hızlı tüketilen içerikler yerine kalıcı ve referans alınabilir bilgiler sunmayı amaçlar. Yeni başlayanlardan deneyimli dalıcılara kadar herkes için, okunabilir, sade ve güvenilir bir kaynak oluşturur.</p>
+            <div
+              class="is-align-content-center px-6 py-5"
+              style="max-width: 600px"
+            >
+              <h2 class="title is-2 mb-4">
+                <span class="has-text-primary">Dipnot</span> nedir?
+              </h2>
+              <p class="mt-3">
+                Dipnot, dalış ve su altı dünyasına ilgi duyan herkes için
+                hazırlanmış bağımsız bir içerik platformudur. Uygulama içinde;
+                dalış kültürü, güvenlik, ekipman, çevre, tarih ve güncel konular
+                üzerine özenle yazılmış makalelere ulaşabilirsiniz.
+              </p>
+              <p class="mt-3">
+                Dipnot, hızlı tüketilen içerikler yerine kalıcı ve referans
+                alınabilir bilgiler sunmayı amaçlar. Yeni başlayanlardan
+                deneyimli dalıcılara kadar herkes için, okunabilir, sade ve
+                güvenilir bir kaynak oluşturur.
+              </p>
             </div>
           </div>
         </div>
@@ -68,7 +95,9 @@ hasContactForm: true
   <section id="features" class="section my-6">
     <div class="has-text-centered mb-6">
       <h2 class="title is-2 mb-4">Özellikler</h2>
-      <p class="subtitle mb-6">Dalış odaklı, sade ve nitelikli bir içerik deneyimi</p>
+      <p class="subtitle mb-6">
+        Dalış odaklı, sade ve nitelikli bir içerik deneyimi
+      </p>
     </div>
 
     <div class="columns is-multiline">
@@ -122,11 +151,16 @@ hasContactForm: true
       </div>
 
       <div class="column">
-        <div class="card p-4 has-background-info has-text-dark has-text-centered">
-          <div class="card-header is-flex-direction-column" style="box-shadow: none;">
+        <div
+          class="card p-4 has-background-info has-text-dark has-text-centered"
+        >
+          <div
+            class="card-header is-flex-direction-column"
+            style="box-shadow: none"
+          >
             <div class="title has-text-dark">
               <figure class="image is-128x128 m-auto">
-                <img src="/img/apw-Icon2.png" alt="Ücretsiz indir">
+                <img src="/img/apw-Icon2.png" alt="Ücretsiz indir" />
               </figure>
 
               <h3 class="is-size-3 mt-4">Ücretsiz indir</h3>
@@ -140,11 +174,16 @@ hasContactForm: true
       </div>
 
       <div class="column">
-        <div class="card p-4 has-background-danger has-text-dark has-text-centered">
-          <div class="card-header is-flex-direction-column" style="box-shadow: none;">
+        <div
+          class="card p-4 has-background-danger has-text-dark has-text-centered"
+        >
+          <div
+            class="card-header is-flex-direction-column"
+            style="box-shadow: none"
+          >
             <div class="title has-text-dark">
               <figure class="image is-128x128 m-auto">
-                <img src="/img/apw-Icon1.png" alt="Profil oluştur">
+                <img src="/img/apw-Icon1.png" alt="Profil oluştur" />
               </figure>
 
               <h3 class="is-size-3 mt-4">Profil oluştur</h3>
@@ -158,11 +197,16 @@ hasContactForm: true
       </div>
 
       <div class="column">
-        <div class="card p-4 has-background-warning has-text-dark has-text-centered">
-          <div class="card-header is-flex-direction-column" style="box-shadow: none;">
+        <div
+          class="card p-4 has-background-warning has-text-dark has-text-centered"
+        >
+          <div
+            class="card-header is-flex-direction-column"
+            style="box-shadow: none"
+          >
             <div class="title has-text-dark">
               <figure class="image is-128x128 m-auto">
-                <img src="/img/apw-Icon3.png" alt="İçerikleri keşfet">
+                <img src="/img/apw-Icon3.png" alt="İçerikleri keşfet" />
               </figure>
 
               <h3 class="is-size-3 mt-4">İçerikleri keşfet</h3>
@@ -170,22 +214,24 @@ hasContactForm: true
           </div>
 
           <div class="card-content">
-            <p>Dalış ve su altı dünyasına dair farklı başlıklar altında hazırlanmış makalelere kolayca ulaş.</p>
+            <p>
+              Dalış ve su altı dünyasına dair farklı başlıklar altında
+              hazırlanmış makalelere kolayca ulaş.
+            </p>
           </div>
         </div>
       </div>
-
     </div>
   </section>
 
-  <hr class="my-6">
+  <hr class="my-6" />
 
   <!-- F.A.Q. -->
   <section id="faq" class="section">
     <div class="columns">
       <div class="column is-5 mt-5">
         <figure class="image">
-          <img src="/img/deviceframes-sss.png" alt="FAQ DeviceFrames">
+          <img src="/img/deviceframes-sss.png" alt="FAQ DeviceFrames" />
         </figure>
       </div>
 
@@ -194,76 +240,111 @@ hasContactForm: true
 
         <div class="card">
           <header class="card-header is-clickable">
-            <p class="card-header-title">Dipnot'ta ne tür içerikler bulabilirim?</p>
-            <button type="button" class="card-header-icon" aria-label="SSS cevabını aç veya kapat">
+            <p class="card-header-title">
+              Dipnot'ta ne tür içerikler bulabilirim?
+            </p>
+            <button
+              type="button"
+              class="card-header-icon"
+              aria-label="SSS cevabını aç veya kapat"
+            >
               <span class="icon">
                 <i class="fas fa-angle-down faq-icon" aria-hidden="true"></i>
               </span>
             </button>
           </header>
           <div class="card-content faq-content">
-            Dipnot'ta dalış güvenliği, ekipman, çevre, tarih ve dalış kültürü gibi farklı başlıklar altında hazırlanmış, derinlikli makaleler bulabilirsin. İçerikler hızlı tüketim için değil, tekrar tekrar başvurulabilecek şekilde hazırlanır.
+            Dipnot'ta dalış güvenliği, ekipman, çevre, tarih ve dalış kültürü
+            gibi farklı başlıklar altında hazırlanmış, derinlikli makaleler
+            bulabilirsin. İçerikler hızlı tüketim için değil, tekrar tekrar
+            başvurulabilecek şekilde hazırlanır.
           </div>
         </div>
 
         <div class="card">
           <header class="card-header is-clickable">
-            <p class="card-header-title">Dipnot'u diğer dalış bloglarından ayıran nedir?</p>
-            <button type="button" class="card-header-icon" aria-label="SSS cevabını aç veya kapat">
+            <p class="card-header-title">
+              Dipnot'u diğer dalış bloglarından ayıran nedir?
+            </p>
+            <button
+              type="button"
+              class="card-header-icon"
+              aria-label="SSS cevabını aç veya kapat"
+            >
               <span class="icon">
                 <i class="fas fa-angle-down faq-icon" aria-hidden="true"></i>
               </span>
             </button>
           </header>
           <div class="card-content faq-content is-hidden">
-            Dipnot, dağınık içerikler yerine tek bir platformda, küratörlü ve düzenli bir okuma deneyimi sunar. Reklam odaklı değil, bilgi odaklıdır.
+            Dipnot, dağınık içerikler yerine tek bir platformda, küratörlü ve
+            düzenli bir okuma deneyimi sunar. Reklam odaklı değil, bilgi
+            odaklıdır.
           </div>
         </div>
 
         <div class="card">
           <header class="card-header is-clickable">
             <p class="card-header-title">Uygulama tamamen ücretsiz mi?</p>
-            <button type="button" class="card-header-icon" aria-label="SSS cevabını aç veya kapat">
+            <button
+              type="button"
+              class="card-header-icon"
+              aria-label="SSS cevabını aç veya kapat"
+            >
               <span class="icon">
                 <i class="fas fa-angle-down faq-icon" aria-hidden="true"></i>
               </span>
             </button>
           </header>
           <div class="card-content faq-content is-hidden">
-            Dipnot'un temel içeriklerine ücretsiz olarak erişebilirsin. İlerleyen dönemde, özel dosyalar ve derinlemesine içerikler için ücretli üyelik seçenekleri sunulacaktır.
+            Dipnot'un temel içeriklerine ücretsiz olarak erişebilirsin.
+            İlerleyen dönemde, özel dosyalar ve derinlemesine içerikler için
+            ücretli üyelik seçenekleri sunulacaktır.
           </div>
         </div>
 
         <div class="card">
           <header class="card-header is-clickable">
-            <p class="card-header-title">Yeni içerikler ne sıklıkla yayınlanıyor?</p>
-            <button type="button" class="card-header-icon" aria-label="SSS cevabını aç veya kapat">
+            <p class="card-header-title">
+              Yeni içerikler ne sıklıkla yayınlanıyor?
+            </p>
+            <button
+              type="button"
+              class="card-header-icon"
+              aria-label="SSS cevabını aç veya kapat"
+            >
               <span class="icon">
                 <i class="fas fa-angle-down faq-icon" aria-hidden="true"></i>
               </span>
             </button>
           </header>
           <div class="card-content faq-content is-hidden">
-            Yeni makaleler düzenli olarak eklenir. Profil oluşturarak ilgi alanlarını seçebilir ve yayınlanan içerikleri kolayca takip edebilirsin.
+            Yeni makaleler düzenli olarak eklenir. Profil oluşturarak ilgi
+            alanlarını seçebilir ve yayınlanan içerikleri kolayca takip
+            edebilirsin.
           </div>
         </div>
-
       </div>
     </div>
   </section>
 
   <!-- DOWNLOAD -->
-  <div class="hero has-background-hero my-6" style="border-radius: 1em;">
+  <div class="hero has-background-hero my-6" style="border-radius: 1em">
     <div class="hero-body has-text-centered">
-      <p class="title is-size-1 has-text-white mb-4">Kullanmaya <span class="has-text-primary">ücretsiz</span> başla!</p>
-      <p class="subtitle has-text-white">Teknikten tarihe, güvenlikten çevreye dalış dünyasını derinlemesine ele alan içerikler...</p>
+      <p class="title is-size-1 has-text-white mb-4">
+        Kullanmaya <span class="has-text-primary">ücretsiz</span> başla!
+      </p>
+      <p class="subtitle has-text-white">
+        Teknikten tarihe, güvenlikten çevreye dalış dünyasını derinlemesine ele
+        alan içerikler...
+      </p>
       <div class="buttons are-large mt-6 is-flex is-justify-content-center">
         <button type="button" class="button is-light is-outlined is-rounded">
-          <img src="/img/svg/google-play.svg" alt="Google Play">
+          <img src="/img/svg/google-play.svg" alt="Google Play" />
           <span class="ml-2">Google Play</span>
         </button>
         <button type="button" class="button is-light is-rounded">
-          <img src="/img/svg/app-store.svg" alt="App Store">
+          <img src="/img/svg/app-store.svg" alt="App Store" />
           <span class="ml-2">App Store</span>
         </button>
       </div>
@@ -273,7 +354,6 @@ hasContactForm: true
   <!-- Contact -->
   <section id="contact" class="section">
     <div class="container">
-
       <div class="columns is-centered">
         <div class="column is-6">
           <div class="card">
@@ -285,21 +365,32 @@ hasContactForm: true
             </div>
 
             <div class="card-content">
-
               <!-- Contact Form -->
               <form id="contact-form">
-
                 <!-- Honeypot (spam trap — bots fill this, humans don't see it) -->
                 <div class="is-hidden" aria-hidden="true">
                   <label for="contact-website">Website</label>
-                  <input id="contact-website" name="website" type="text" tabindex="-1" autocomplete="off">
+                  <input
+                    id="contact-website"
+                    name="website"
+                    type="text"
+                    tabindex="-1"
+                    autocomplete="off"
+                  />
                 </div>
 
                 <!-- Name -->
                 <div class="field">
                   <label class="label" for="contact-name">Ad soyad</label>
                   <div class="control has-icons-left">
-                    <input id="contact-name" name="name" class="input" type="text" placeholder="Adınız ve soyadınız" required>
+                    <input
+                      id="contact-name"
+                      name="name"
+                      class="input"
+                      type="text"
+                      placeholder="Adınız ve soyadınız"
+                      required
+                    />
                     <span class="icon is-small is-left">
                       <i class="fa-solid fa-user"></i>
                     </span>
@@ -310,7 +401,14 @@ hasContactForm: true
                 <div class="field">
                   <label class="label" for="contact-email">E-posta</label>
                   <div class="control has-icons-left">
-                    <input id="contact-email" name="email" class="input" type="email" placeholder="eposta@ornek.com" required>
+                    <input
+                      id="contact-email"
+                      name="email"
+                      class="input"
+                      type="email"
+                      placeholder="eposta@ornek.com"
+                      required
+                    />
                     <span class="icon is-small is-left">
                       <i class="fa-solid fa-envelope"></i>
                     </span>
@@ -336,7 +434,13 @@ hasContactForm: true
                 <div class="field">
                   <label class="label" for="contact-message">Mesaj</label>
                   <div class="control">
-                    <textarea id="contact-message" name="message" class="textarea" placeholder="Mesajınızı buraya yazın..." required></textarea>
+                    <textarea
+                      id="contact-message"
+                      name="message"
+                      class="textarea"
+                      placeholder="Mesajınızı buraya yazın..."
+                      required
+                    ></textarea>
                   </div>
                 </div>
 
@@ -344,9 +448,22 @@ hasContactForm: true
                 <div class="field">
                   <div class="control">
                     <label class="checkbox">
-                      <input type="checkbox" required>
+                      <input type="checkbox" required />
                       <span>
-                        <a href="/kullanim-kosullari.html" target="_blank" rel="noopener noreferrer">Kullanım koşulları</a> ve <a href="/gizlilik-politikasi.html" target="_blank" rel="noopener noreferrer">Gizlilik politikası</a> bilgilendirme metinlerini okudum ve kabul ediyorum.
+                        <a
+                          href="/kullanim-kosullari.html"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          >Kullanım koşulları</a
+                        >
+                        ve
+                        <a
+                          href="/gizlilik-politikasi.html"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          >Gizlilik politikası</a
+                        >
+                        bilgilendirme metinlerini okudum ve kabul ediyorum.
                       </span>
                     </label>
                   </div>
@@ -355,23 +472,28 @@ hasContactForm: true
                 <!-- Submit -->
                 <div class="field">
                   <div class="control has-text-centered">
-                    <button type="submit" class="button is-primary is-fullwidth">
+                    <button
+                      type="submit"
+                      class="button is-primary is-fullwidth"
+                    >
                       Gönder
                     </button>
                   </div>
                 </div>
 
                 <!-- Feedback (success/error) -->
-                <p id="contact-feedback" class="help mt-3" role="status" aria-live="polite"></p>
-
+                <p
+                  id="contact-feedback"
+                  class="help mt-3"
+                  role="status"
+                  aria-live="polite"
+                ></p>
               </form>
               <!-- /Contact Form -->
-
             </div>
           </div>
         </div>
       </div>
     </div>
   </section>
-
 </main>

--- a/js/contact.js
+++ b/js/contact.js
@@ -40,7 +40,7 @@
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
-        }
+        },
       );
 
       const data = await res.json();

--- a/js/main.js
+++ b/js/main.js
@@ -1,60 +1,60 @@
 // FAQ
-document.querySelectorAll('#faq .card-header').forEach(header => {
-  header.addEventListener('click', () => {
+document.querySelectorAll("#faq .card-header").forEach((header) => {
+  header.addEventListener("click", () => {
     const card = header.parentElement;
-    const content = card.querySelector('.faq-content');
-    const icon = card.querySelector('.faq-icon');
+    const content = card.querySelector(".faq-content");
+    const icon = card.querySelector(".faq-icon");
 
-    content.classList.toggle('is-hidden');
-    icon.classList.toggle('is-rotated');
+    content.classList.toggle("is-hidden");
+    icon.classList.toggle("is-rotated");
   });
 });
 
 // Mobile navbar toggle (Bulma)
-document.addEventListener('DOMContentLoaded', () => {
-  const burgers = document.querySelectorAll('.navbar-burger');
+document.addEventListener("DOMContentLoaded", () => {
+  const burgers = document.querySelectorAll(".navbar-burger");
 
-  burgers.forEach(burger => {
-    burger.addEventListener('click', () => {
+  burgers.forEach((burger) => {
+    burger.addEventListener("click", () => {
       const targetId = burger.dataset.target;
       const target = document.getElementById(targetId);
 
-      burger.classList.toggle('is-active');
-      target.classList.toggle('is-active');
+      burger.classList.toggle("is-active");
+      target.classList.toggle("is-active");
     });
   });
 });
 
 // Theme Toggle (desktop + mobile)
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   const themeToggles = document.querySelectorAll(
-    '#theme-toggle, #theme-toggle-mobile'
+    "#theme-toggle, #theme-toggle-mobile",
   );
 
   if (!themeToggles.length) return;
 
   const getTheme = () =>
-    document.documentElement.getAttribute('data-theme') || 'dark';
+    document.documentElement.getAttribute("data-theme") || "dark";
 
   const setTheme = (theme) => {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
 
-    themeToggles.forEach(toggle => {
+    themeToggles.forEach((toggle) => {
       toggle.innerHTML =
-        theme === 'dark'
+        theme === "dark"
           ? '<span class="icon"><i class="fa-solid fa-moon has-text-link"></i></span>'
           : '<span class="icon"><i class="fa-solid fa-sun has-text-warning"></i></span>';
     });
   };
 
   // Initial sync
-  setTheme(localStorage.getItem('theme') || getTheme());
+  setTheme(localStorage.getItem("theme") || getTheme());
 
   // Click handlers
-  themeToggles.forEach(toggle => {
-    toggle.addEventListener('click', () => {
-      setTheme(getTheme() === 'dark' ? 'light' : 'dark');
+  themeToggles.forEach((toggle) => {
+    toggle.addEventListener("click", () => {
+      setTheme(getTheme() === "dark" ? "light" : "dark");
     });
   });
 });

--- a/js/newsletter.js
+++ b/js/newsletter.js
@@ -24,7 +24,7 @@
           body: JSON.stringify({
             email: emailInput.value,
           }),
-        }
+        },
       );
 
       const data = await res.json();

--- a/kullanim-kosullari.html
+++ b/kullanim-kosullari.html
@@ -14,12 +14,15 @@ og:
   localeAlternate: en_US
   url: "https://dipnot.app/kullanim-kosullari.html"
 ---
+
 <!-- HERO BANNER -->
 <section class="hero has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column">
-        <p class="title is-size-1 has-text-white mb-5">Kullanım <span class="has-text-primary">Koşulları</span></p>
+        <p class="title is-size-1 has-text-white mb-5">
+          Kullanım <span class="has-text-primary">Koşulları</span>
+        </p>
       </div>
     </div>
   </div>
@@ -27,84 +30,197 @@ og:
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-
   <!-- CONTENT -->
   <section class="section">
     <div class="content">
       <h1>Kullanım Koşulları</h1>
-      <p><strong>Son Güncelleme:</strong> <time datetime="2026-04-06">6 Nisan 2026</time></p>
+      <p>
+        <strong>Son Güncelleme:</strong>
+        <time datetime="2026-04-06">6 Nisan 2026</time>
+      </p>
 
       <h2>1. Hükümlerin Kabulü</h2>
-      <p>Dipnot mobil uygulamasını ("Uygulama") indirerek, yükleyerek veya herhangi bir şekilde kullanarak, işbu Kullanım Koşulları'nı ("Koşullar") eksiksiz ve koşulsuz olarak kabul etmiş olursunuz. Koşulları kabul etmiyorsanız lütfen uygulamayı kullanmayın.</p>
+      <p>
+        Dipnot mobil uygulamasını ("Uygulama") indirerek, yükleyerek veya
+        herhangi bir şekilde kullanarak, işbu Kullanım Koşulları'nı ("Koşullar")
+        eksiksiz ve koşulsuz olarak kabul etmiş olursunuz. Koşulları kabul
+        etmiyorsanız lütfen uygulamayı kullanmayın.
+      </p>
 
       <h2>2. Hizmetin Tanımı</h2>
-      <p>Dipnot, Türkiye Cumhuriyeti sınırları içerisinde faaliyet gösteren, scuba dalışı alanında makale, haber, rehber ve video içeriklerinin yayınlandığı bir mobil platformdur. Kullanıcılar ücretsiz olarak içerikleri okuyabilir, kaydedebilir ve kişiselleştirilmiş bir deneyim elde edebilir.</p>
+      <p>
+        Dipnot, Türkiye Cumhuriyeti sınırları içerisinde faaliyet gösteren,
+        scuba dalışı alanında makale, haber, rehber ve video içeriklerinin
+        yayınlandığı bir mobil platformdur. Kullanıcılar ücretsiz olarak
+        içerikleri okuyabilir, kaydedebilir ve kişiselleştirilmiş bir deneyim
+        elde edebilir.
+      </p>
 
       <h2>3. Hesap Oluşturma ve Güvenlik</h2>
-      <p>Uygulamanın tam işlevselliğinden yararlanmak için bir hesap oluşturmanız ve doğru, güncel ve eksiksiz bilgiler (ad, soyad, e-posta, telefon) vermeniz gerekmektedir.</p>
+      <p>
+        Uygulamanın tam işlevselliğinden yararlanmak için bir hesap oluşturmanız
+        ve doğru, güncel ve eksiksiz bilgiler (ad, soyad, e-posta, telefon)
+        vermeniz gerekmektedir.
+      </p>
       <ul>
-        <li>E-posta doğrulaması zorunludur. Doğrulanmamış hesaplar sınırlı erişime sahip olabilir veya belirli bir süre sonra silinebilir.</li>
-        <li>Hesap şifrenizin gizliliğinden ve hesabınız altında gerçekleştirilen tüm faaliyetlerden yalnızca siz sorumlusunuz. Şifrenizi üçüncü kişilerle paylaşmayın.</li>
-        <li>Hesabınızın izinsiz kullanıldığını fark ederseniz derhal help@dipnot.app adresine bildirin.</li>
+        <li>
+          E-posta doğrulaması zorunludur. Doğrulanmamış hesaplar sınırlı erişime
+          sahip olabilir veya belirli bir süre sonra silinebilir.
+        </li>
+        <li>
+          Hesap şifrenizin gizliliğinden ve hesabınız altında gerçekleştirilen
+          tüm faaliyetlerden yalnızca siz sorumlusunuz. Şifrenizi üçüncü
+          kişilerle paylaşmayın.
+        </li>
+        <li>
+          Hesabınızın izinsiz kullanıldığını fark ederseniz derhal
+          help@dipnot.app adresine bildirin.
+        </li>
       </ul>
 
       <h2>4. Kullanıcı Yükümlülükleri</h2>
       <p>Uygulamayı kullanırken aşağıdaki eylemler kesinlikle yasaktır:</p>
       <ul>
-        <li>Uygulamanın veya sunucularının işleyişine zarar verecek, aşırı yük bindirecek veya güvenlik açıklarından yararlanacak faaliyetlerde bulunmak.</li>
-        <li>Yasadışı, tehdit edici, taciz edici, nefret söylemi içeren, şiddeti teşvik eden veya başkalarının haklarını (fikri mülkiyet, gizlilik vb.) ihlal eden içerikler paylaşmak (yorumlar, profil bilgileri).</li>
-        <li>Başka bir kullanıcının hesabına izinsiz erişmeye çalışmak, parola veya güvenlik tokenlarını çalmak.</li>
-        <li>Uygulamayı tersine mühendislik yöntemiyle incelemek, kaynak kodunu çıkarmak veya kopyalamak.</li>
+        <li>
+          Uygulamanın veya sunucularının işleyişine zarar verecek, aşırı yük
+          bindirecek veya güvenlik açıklarından yararlanacak faaliyetlerde
+          bulunmak.
+        </li>
+        <li>
+          Yasadışı, tehdit edici, taciz edici, nefret söylemi içeren, şiddeti
+          teşvik eden veya başkalarının haklarını (fikri mülkiyet, gizlilik vb.)
+          ihlal eden içerikler paylaşmak (yorumlar, profil bilgileri).
+        </li>
+        <li>
+          Başka bir kullanıcının hesabına izinsiz erişmeye çalışmak, parola veya
+          güvenlik tokenlarını çalmak.
+        </li>
+        <li>
+          Uygulamayı tersine mühendislik yöntemiyle incelemek, kaynak kodunu
+          çıkarmak veya kopyalamak.
+        </li>
         <li>Uygulama üzerinden spam, phishing veya zararlı yazılım yaymak.</li>
       </ul>
-      <p>Bu yükümlülükleri ihlal ettiğiniz takdirde Dipnot, hesabınızı geçici veya kalıcı olarak askıya alma veya silme hakkını saklı tutar.</p>
+      <p>
+        Bu yükümlülükleri ihlal ettiğiniz takdirde Dipnot, hesabınızı geçici
+        veya kalıcı olarak askıya alma veya silme hakkını saklı tutar.
+      </p>
 
       <h2>5. Fikri Mülkiyet Hakları</h2>
       <ul>
-        <li>Dipnot uygulamasının tüm içeriği (makaleler, görseller, videolar, logolar, grafikler, yazılım kodu, tasarım) aksi belirtilmedikçe Dipnot'a veya lisans sağlayıcılarına aittir ve uluslararası telif hakkı, marka ve fikri mülkiyet yasalarıyla korunmaktadır.</li>
-        <li>İçerikleri kişisel, ticari olmayan kullanımınız için görüntüleyebilir ve kaydedebilirsiniz. <strong>Ancak izinsiz olarak kopyalayamaz, dağıtamaz, yeniden yayınlayamaz, satamaz veya ticari amaçla kullanamazsınız.</strong></li>
-        <li>"Dipnot" adı ve logosu tescilli marka adayıdır. Kullanımı için yazılı izin gereklidir.</li>
+        <li>
+          Dipnot uygulamasının tüm içeriği (makaleler, görseller, videolar,
+          logolar, grafikler, yazılım kodu, tasarım) aksi belirtilmedikçe
+          Dipnot'a veya lisans sağlayıcılarına aittir ve uluslararası telif
+          hakkı, marka ve fikri mülkiyet yasalarıyla korunmaktadır.
+        </li>
+        <li>
+          İçerikleri kişisel, ticari olmayan kullanımınız için görüntüleyebilir
+          ve kaydedebilirsiniz.
+          <strong
+            >Ancak izinsiz olarak kopyalayamaz, dağıtamaz, yeniden yayınlayamaz,
+            satamaz veya ticari amaçla kullanamazsınız.</strong
+          >
+        </li>
+        <li>
+          "Dipnot" adı ve logosu tescilli marka adayıdır. Kullanımı için yazılı
+          izin gereklidir.
+        </li>
       </ul>
 
       <h2>6. Kullanıcı Tarafından Oluşturulan İçerik (UGC)</h2>
-      <p>Uygulamanın ileriki sürümlerinde (örneğin yorum veya topluluk bölümü) içerik paylaşımına izin verilmesi durumunda:</p>
+      <p>
+        Uygulamanın ileriki sürümlerinde (örneğin yorum veya topluluk bölümü)
+        içerik paylaşımına izin verilmesi durumunda:
+      </p>
       <ul>
-        <li>Paylaştığınız içeriklerin telif hakları size ait olmaya devam eder; ancak Dipnot'a bu içerikleri uygulama içinde sınırsız süreyle kullanma, çoğaltma, dağıtma ve işleme hakkını verirsiniz.</li>
-        <li>Paylaştığınız içeriklerden yasal olarak siz sorumlusunuz. Dipnot, uygunsuz içerikleri yayından kaldırma hakkını saklı tutar.</li>
+        <li>
+          Paylaştığınız içeriklerin telif hakları size ait olmaya devam eder;
+          ancak Dipnot'a bu içerikleri uygulama içinde sınırsız süreyle
+          kullanma, çoğaltma, dağıtma ve işleme hakkını verirsiniz.
+        </li>
+        <li>
+          Paylaştığınız içeriklerden yasal olarak siz sorumlusunuz. Dipnot,
+          uygunsuz içerikleri yayından kaldırma hakkını saklı tutar.
+        </li>
       </ul>
 
       <h2>7. Hizmetin Değiştirilmesi ve Sonlandırılması</h2>
-      <p>Dipnot, herhangi bir zamanda, önceden bildirimde bulunarak veya bulunmaksızın:</p>
+      <p>
+        Dipnot, herhangi bir zamanda, önceden bildirimde bulunarak veya
+        bulunmaksızın:
+      </p>
       <ul>
-        <li>Uygulamanın tamamını veya bir kısmını geçici veya kalıcı olarak durdurabilir veya değiştirebilir.</li>
+        <li>
+          Uygulamanın tamamını veya bir kısmını geçici veya kalıcı olarak
+          durdurabilir veya değiştirebilir.
+        </li>
         <li>Belirli özelliklere erişimi kısıtlayabilir.</li>
-        <li>Hesabınızı, Koşulları ihlal ettiğiniz takdirde askıya alabilir veya silebilir.</li>
+        <li>
+          Hesabınızı, Koşulları ihlal ettiğiniz takdirde askıya alabilir veya
+          silebilir.
+        </li>
       </ul>
-      <p>Uygulamanın durdurulması veya hesabınızın silinmesi durumunda, Dipnot size herhangi bir tazminat ödemekle yükümlü değildir.</p>
+      <p>
+        Uygulamanın durdurulması veya hesabınızın silinmesi durumunda, Dipnot
+        size herhangi bir tazminat ödemekle yükümlü değildir.
+      </p>
 
       <h2>8. Sorumluluğun Sınırlandırılması</h2>
       <ul>
-        <li>Dipnot, uygulamanın kesintisiz, hatasız, güvenli veya virüssüz olacağını garanti etmez. Uygulama "olduğu gibi" ve "erişilebilir olduğu kadarıyla" sunulmaktadır.</li>
-        <li>Uygulamanın kullanımından veya kullanılamamasından doğabilecek doğrudan, dolaylı, arızi, özel veya sonuç olarak ortaya çıkan hiçbir zarardan (kâr kaybı, veri kaybı, itibar zararı vb.) Dipnot sorumlu tutulamaz.</li>
-        <li>Yürürlükteki yasanın zorunlu kıldığı durumlar hariç, Dipnot'un toplam sorumluluğu, son 12 ayda uygulama için ödediğiniz ücretleri (eğer varsa) aşmaz. Dipnot ücretsiz bir uygulama olduğu için sorumluluk 0 (sıfır) TL olarak kabul edilir.</li>
+        <li>
+          Dipnot, uygulamanın kesintisiz, hatasız, güvenli veya virüssüz
+          olacağını garanti etmez. Uygulama "olduğu gibi" ve "erişilebilir
+          olduğu kadarıyla" sunulmaktadır.
+        </li>
+        <li>
+          Uygulamanın kullanımından veya kullanılamamasından doğabilecek
+          doğrudan, dolaylı, arızi, özel veya sonuç olarak ortaya çıkan hiçbir
+          zarardan (kâr kaybı, veri kaybı, itibar zararı vb.) Dipnot sorumlu
+          tutulamaz.
+        </li>
+        <li>
+          Yürürlükteki yasanın zorunlu kıldığı durumlar hariç, Dipnot'un toplam
+          sorumluluğu, son 12 ayda uygulama için ödediğiniz ücretleri (eğer
+          varsa) aşmaz. Dipnot ücretsiz bir uygulama olduğu için sorumluluk 0
+          (sıfır) TL olarak kabul edilir.
+        </li>
       </ul>
 
       <h2>9. Üçüncü Taraf Bağlantılar ve Hizmetler</h2>
-      <p>Uygulama, WordPress gibi üçüncü taraf web sitelerine bağlantılar içerebilir. Bu sitelerin gizlilik uygulamalarından veya içeriklerinden Dipnot sorumlu değildir. Bağlantılara tıklamak tamamen kendi sorumluluğunuzdadır.</p>
+      <p>
+        Uygulama, WordPress gibi üçüncü taraf web sitelerine bağlantılar
+        içerebilir. Bu sitelerin gizlilik uygulamalarından veya içeriklerinden
+        Dipnot sorumlu değildir. Bağlantılara tıklamak tamamen kendi
+        sorumluluğunuzdadır.
+      </p>
 
       <h2>10. Koşullarda Değişiklik</h2>
-      <p>Dipnot, bu Koşulları herhangi bir zamanda değiştirme hakkını saklı tutar. Önemli değişiklikler şu yollarla duyurulacaktır:</p>
+      <p>
+        Dipnot, bu Koşulları herhangi bir zamanda değiştirme hakkını saklı
+        tutar. Önemli değişiklikler şu yollarla duyurulacaktır:
+      </p>
       <ul>
         <li>Uygulama içi bildirim (en az 7 gün önceden)</li>
         <li>Kayıtlı e-posta adresinize gönderilen bildirim</li>
       </ul>
-      <p>Değişikliklerin yürürlüğe girmesinden sonra uygulamayı kullanmaya devam etmeniz, yeni Koşulları kabul ettiğiniz anlamına gelir.</p>
+      <p>
+        Değişikliklerin yürürlüğe girmesinden sonra uygulamayı kullanmaya devam
+        etmeniz, yeni Koşulları kabul ettiğiniz anlamına gelir.
+      </p>
 
       <h2>11. Uygulanacak Hukuk ve Yetki</h2>
-      <p>İşbu Koşullar, Türkiye Cumhuriyeti kanunlarına tabidir. Koşullardan doğan veya bunlarla ilgili her türlü uyuşmazlıkta, İstanbul (Çağlayan) Mahkemeleri ve İcra Daireleri yetkilidir.</p>
+      <p>
+        İşbu Koşullar, Türkiye Cumhuriyeti kanunlarına tabidir. Koşullardan
+        doğan veya bunlarla ilgili her türlü uyuşmazlıkta, İstanbul (Çağlayan)
+        Mahkemeleri ve İcra Daireleri yetkilidir.
+      </p>
 
       <h2>12. İletişim</h2>
-      <p>Bu Koşullar veya uygulama hakkında sorularınız, şikayetleriniz veya önerileriniz için bize şu adresten ulaşabilirsiniz:</p>
+      <p>
+        Bu Koşullar veya uygulama hakkında sorularınız, şikayetleriniz veya
+        önerileriniz için bize şu adresten ulaşabilirsiniz:
+      </p>
       <p>
         <span class="icon mr-2">
           <i class="fa-solid fa-envelope"></i>
@@ -113,5 +229,4 @@ og:
       </p>
     </div>
   </section>
-
 </main>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -15,12 +15,16 @@ og:
   url: "https://dipnot.app/privacy-policy.html"
   description: "Dipnot Privacy Policy (KVKK) — how your personal data is processed."
 ---
+
 <!-- HERO BANNER -->
 <section class="hero has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column">
-        <p class="title is-size-1 has-text-white mb-5">Privacy <span class="has-text-primary">Policy</span> <span style="white-space: nowrap;">(KVKK)</span></p>
+        <p class="title is-size-1 has-text-white mb-5">
+          Privacy <span class="has-text-primary">Policy</span>
+          <span style="white-space: nowrap">(KVKK)</span>
+        </p>
       </div>
     </div>
   </div>
@@ -28,26 +32,43 @@ og:
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-
   <!-- CONTENT -->
   <section class="section">
     <div class="content">
       <h1>Privacy Policy (KVKK)</h1>
-      <p><strong>Last updated:</strong> <time datetime="2026-04-24">24 April 2026</time></p>
+      <p>
+        <strong>Last updated:</strong>
+        <time datetime="2026-04-24">24 April 2026</time>
+      </p>
 
       <div class="notification is-warning">
-        <p><strong>Note:</strong> This English version is provided for convenience. The Turkish version, <a href="/gizlilik-politikasi.html">Gizlilik Politikası ve Aydınlatma Metni</a>, is authoritative under Turkish law (KVKK) in case of any conflict.</p>
+        <p>
+          <strong>Note:</strong> This English version is provided for
+          convenience. The Turkish version,
+          <a href="/gizlilik-politikasi.html"
+            >Gizlilik Politikası ve Aydınlatma Metni</a
+          >, is authoritative under Turkish law (KVKK) in case of any conflict.
+        </p>
       </div>
 
       <h2>1. Data Controller</h2>
-      <p>Under the Turkish Personal Data Protection Law No. 6698 ("KVKK"), your personal data is processed by the team operating the "Dipnot" application as data controller, within the scope described below.</p>
+      <p>
+        Under the Turkish Personal Data Protection Law No. 6698 ("KVKK"), your
+        personal data is processed by the team operating the "Dipnot"
+        application as data controller, within the scope described below.
+      </p>
       <ul>
         <li>Data Controller: Dipnot Application Team</li>
         <li>Contact email: help@dipnot.app</li>
       </ul>
 
-      <h2>2. Personal Data Collected, Purposes of Processing, and Legal Basis</h2>
-      <p>When you register for and use the Dipnot application, the following data is processed:</p>
+      <h2>
+        2. Personal Data Collected, Purposes of Processing, and Legal Basis
+      </h2>
+      <p>
+        When you register for and use the Dipnot application, the following data
+        is processed:
+      </p>
       <table class="table">
         <thead>
           <tr>
@@ -67,18 +88,25 @@ og:
           <tr>
             <th scope="row">Contact</th>
             <td>Email address, Phone number</td>
-            <td>Account verification (email verification), password reset, sending notifications, communicating with the user</td>
+            <td>
+              Account verification (email verification), password reset, sending
+              notifications, communicating with the user
+            </td>
             <td>Explicit consent</td>
           </tr>
           <tr>
             <th scope="row">Usage Data</th>
             <td>Articles read, likes, saved content, session durations</td>
-            <td>Content recommendations, improving the experience, trend analysis</td>
+            <td>
+              Content recommendations, improving the experience, trend analysis
+            </td>
             <td>Legitimate interest</td>
           </tr>
           <tr>
             <th scope="row">Technical Data</th>
-            <td>Device model, operating system version, IP address, app version</td>
+            <td>
+              Device model, operating system version, IP address, app version
+            </td>
             <td>Ensuring the app works, debugging, security</td>
             <td>Legitimate interest</td>
           </tr>
@@ -86,65 +114,164 @@ og:
       </table>
 
       <h2>3. Third Parties and Cross-Border Transfers</h2>
-      <p>Your personal data may be shared with third parties limited to the following service providers:</p>
+      <p>
+        Your personal data may be shared with third parties limited to the
+        following service providers:
+      </p>
       <ul>
         <li>
-          <strong>Google Firebase and Google Cloud Platform (eur3 – Europe):</strong>
-          <br>
-          <span>For authentication, database (Firestore), file storage (Storage), and push notifications. Your data is hosted on servers in Europe (Frankfurt, eur3).</span>
+          <strong
+            >Google Firebase and Google Cloud Platform (eur3 – Europe):</strong
+          >
+          <br />
+          <span
+            >For authentication, database (Firestore), file storage (Storage),
+            and push notifications. Your data is hosted on servers in Europe
+            (Frankfurt, eur3).</span
+          >
         </li>
         <li>
           <strong>Expo (Expo Application Services, Inc. – USA):</strong>
-          <br>
-          <span>The Dipnot mobile app is built on the Expo / React Native stack. Your push notification tokens are processed through the Expo Push service and used to deliver notifications. Limited device and runtime information (device model, operating system version, app version) may be sent to Expo's servers in the USA for stability monitoring and debugging. Additionally, on every app launch the app sends a lightweight request to Expo's servers (<code>u.expo.dev</code>) to check whether a new JavaScript/asset update is available (OTA — "over-the-air" update); this request includes the app install ID, runtime version, and update channel. These transfers are carried out based on your explicit consent under KVKK article 9.</span>
+          <br />
+          <span
+            >The Dipnot mobile app is built on the Expo / React Native stack.
+            Your push notification tokens are processed through the Expo Push
+            service and used to deliver notifications. Limited device and
+            runtime information (device model, operating system version, app
+            version) may be sent to Expo's servers in the USA for stability
+            monitoring and debugging. Additionally, on every app launch the app
+            sends a lightweight request to Expo's servers
+            (<code>u.expo.dev</code>) to check whether a new JavaScript/asset
+            update is available (OTA — "over-the-air" update); this request
+            includes the app install ID, runtime version, and update channel.
+            These transfers are carried out based on your explicit consent under
+            KVKK article 9.</span
+          >
         </li>
         <li>
           <strong>Google Analytics (Google Analytics for Firebase):</strong>
-          <br>
-          <span>Used to analyse in-app usage statistics, understand user behaviour, and improve the experience. Data collected includes device identifiers, session durations, screen views, and in-app interaction events. We do not share this data with marketing or third-party ad networks. Analytics data is processed on Google's servers in the USA (Google Analytics for Firebase — standard Firebase projects have no user-configurable region setting).</span>
+          <br />
+          <span
+            >Used to analyse in-app usage statistics, understand user behaviour,
+            and improve the experience. Data collected includes device
+            identifiers, session durations, screen views, and in-app interaction
+            events. We do not share this data with marketing or third-party ad
+            networks. Analytics data is processed on Google's servers in the USA
+            (Google Analytics for Firebase — standard Firebase projects have no
+            user-configurable region setting).</span
+          >
         </li>
         <li>
-          <strong>Firebase Cloud Functions — Contact form (Google LLC, europe-west1 – Belgium, EU):</strong>
-          <br>
-          <span>The name, email, subject, and message you submit through the contact form on dipnot.app are processed by Firebase Cloud Functions and stored in Firestore (<code>contactSubmissions</code> collection) to be read by the admin panel. Your IP address and browser information (user-agent) are automatically recorded for abuse investigation and spam prevention. Your data is processed on servers in Europe (Belgium, europe-west1).</span>
+          <strong
+            >Firebase Cloud Functions — Contact form (Google LLC, europe-west1 –
+            Belgium, EU):</strong
+          >
+          <br />
+          <span
+            >The name, email, subject, and message you submit through the
+            contact form on dipnot.app are processed by Firebase Cloud Functions
+            and stored in Firestore (<code>contactSubmissions</code> collection)
+            to be read by the admin panel. Your IP address and browser
+            information (user-agent) are automatically recorded for abuse
+            investigation and spam prevention. Your data is processed on servers
+            in Europe (Belgium, europe-west1).</span
+          >
         </li>
       </ul>
-      <p>Where cross-border transfer is involved, transfers are made under KVKK article 9 to countries with adequate protection (e.g. EU countries) or to service providers that have committed in writing to provide adequate protection. Transfers to US-based providers (including Expo) are carried out with your explicit consent or under the safeguards required by KVKK article 9.</p>
+      <p>
+        Where cross-border transfer is involved, transfers are made under KVKK
+        article 9 to countries with adequate protection (e.g. EU countries) or
+        to service providers that have committed in writing to provide adequate
+        protection. Transfers to US-based providers (including Expo) are carried
+        out with your explicit consent or under the safeguards required by KVKK
+        article 9.
+      </p>
 
       <h2>4. Method of Collection and Legal Basis</h2>
-      <p>Your personal data is obtained when the Dipnot registration form is filled in, through in-app interactions, and via automatic collection of technical data. Our processing activities rely on the following legal bases set out in KVKK article 5:</p>
+      <p>
+        Your personal data is obtained when the Dipnot registration form is
+        filled in, through in-app interactions, and via automatic collection of
+        technical data. Our processing activities rely on the following legal
+        bases set out in KVKK article 5:
+      </p>
       <ul>
         <li>Explicit consent (for identity and contact information)</li>
         <li>Legitimate interest (for analysis of usage and technical data)</li>
       </ul>
 
       <h2>5. Retention Period</h2>
-      <p>Your personal data is retained for as long as the purposes of processing require. This corresponds to the period during which your account is active. When you delete your account or request its deletion, your data is anonymised or erased within 30 days at the latest. Data that must be retained due to legal obligations (e.g. commercial communication records) is kept for the periods specified in the relevant legislation.</p>
+      <p>
+        Your personal data is retained for as long as the purposes of processing
+        require. This corresponds to the period during which your account is
+        active. When you delete your account or request its deletion, your data
+        is anonymised or erased within 30 days at the latest. Data that must be
+        retained due to legal obligations (e.g. commercial communication
+        records) is kept for the periods specified in the relevant legislation.
+      </p>
 
       <h2>6. Data Subject Rights (KVKK art. 11)</h2>
       <p>Under KVKK article 11 you have the following rights:</p>
       <ul>
         <li>To learn whether your personal data is being processed</li>
         <li>To request information if it has been processed</li>
-        <li>To learn the purpose of processing and whether it is used for its intended purpose</li>
-        <li>To know the third parties to whom data has been transferred domestically or abroad</li>
-        <li>To request correction if data has been processed incompletely or incorrectly</li>
-        <li>To request deletion or destruction under the conditions set out in KVKK article 7</li>
-        <li>To request that the above correction and deletion actions be communicated to third parties to whom data has been transferred</li>
-        <li>To object to an outcome adverse to you resulting from analysis of processed data solely by automated systems</li>
-        <li>To claim compensation for damage suffered due to unlawful processing</li>
+        <li>
+          To learn the purpose of processing and whether it is used for its
+          intended purpose
+        </li>
+        <li>
+          To know the third parties to whom data has been transferred
+          domestically or abroad
+        </li>
+        <li>
+          To request correction if data has been processed incompletely or
+          incorrectly
+        </li>
+        <li>
+          To request deletion or destruction under the conditions set out in
+          KVKK article 7
+        </li>
+        <li>
+          To request that the above correction and deletion actions be
+          communicated to third parties to whom data has been transferred
+        </li>
+        <li>
+          To object to an outcome adverse to you resulting from analysis of
+          processed data solely by automated systems
+        </li>
+        <li>
+          To claim compensation for damage suffered due to unlawful processing
+        </li>
       </ul>
-      <p>You can exercise these rights by contacting help@dipnot.app with information sufficient to verify your identity. Your requests will be answered free of charge as soon as possible (within 30 days at the latest).</p>
+      <p>
+        You can exercise these rights by contacting help@dipnot.app with
+        information sufficient to verify your identity. Your requests will be
+        answered free of charge as soon as possible (within 30 days at the
+        latest).
+      </p>
 
       <h2>7. Advertising and Marketing Emails</h2>
-      <p>Dipnot does not currently use any advertising network (AdMob, etc.). If we wish to send informational emails about product updates, new features, or special offers in the future, we will ask for your explicit consent separately. You can give this consent at registration or from the settings screen, and withdraw it at any time.</p>
+      <p>
+        Dipnot does not currently use any advertising network (AdMob, etc.). If
+        we wish to send informational emails about product updates, new
+        features, or special offers in the future, we will ask for your explicit
+        consent separately. You can give this consent at registration or from
+        the settings screen, and withdraw it at any time.
+      </p>
 
       <h2>8. Children's Data</h2>
-      <p>Dipnot does not knowingly or intentionally collect personal data of individuals under 18 years of age. Use of the application by children without parental supervision is not recommended.</p>
+      <p>
+        Dipnot does not knowingly or intentionally collect personal data of
+        individuals under 18 years of age. Use of the application by children
+        without parental supervision is not recommended.
+      </p>
 
       <h2>9. Changes</h2>
-      <p>This Privacy Policy may be updated as needed. Significant changes will be announced through an in-app notification or by email. Continued use of the application after changes take effect means you accept the updated policy.</p>
+      <p>
+        This Privacy Policy may be updated as needed. Significant changes will
+        be announced through an in-app notification or by email. Continued use
+        of the application after changes take effect means you accept the
+        updated policy.
+      </p>
     </div>
   </section>
-
 </main>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -14,12 +14,15 @@ og:
   localeAlternate: tr_TR
   url: "https://dipnot.app/terms-of-use.html"
 ---
+
 <!-- HERO BANNER -->
 <section class="hero has-background-hero">
   <div class="hero-body">
     <div class="columns">
       <div class="column">
-        <p class="title is-size-1 has-text-white mb-5">Terms of <span class="has-text-primary">Use</span></p>
+        <p class="title is-size-1 has-text-white mb-5">
+          Terms of <span class="has-text-primary">Use</span>
+        </p>
       </div>
     </div>
   </div>
@@ -27,88 +30,203 @@ og:
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-
   <!-- CONTENT -->
   <section class="section">
     <div class="content">
       <h1>Terms of Use</h1>
-      <p><strong>Last updated:</strong> <time datetime="2026-04-06">6 April 2026</time></p>
+      <p>
+        <strong>Last updated:</strong>
+        <time datetime="2026-04-06">6 April 2026</time>
+      </p>
 
       <div class="notification is-warning">
-        <p><strong>Note:</strong> This English version is provided for convenience. The Turkish version, <a href="/kullanim-kosullari.html">Kullanım Koşulları</a>, is authoritative under Turkish law in case of any conflict.</p>
+        <p>
+          <strong>Note:</strong> This English version is provided for
+          convenience. The Turkish version,
+          <a href="/kullanim-kosullari.html">Kullanım Koşulları</a>, is
+          authoritative under Turkish law in case of any conflict.
+        </p>
       </div>
 
       <h2>1. Acceptance of Terms</h2>
-      <p>By downloading, installing, or using the Dipnot mobile application (the "Application") in any way, you fully and unconditionally accept these Terms of Use (the "Terms"). If you do not accept the Terms, please do not use the Application.</p>
+      <p>
+        By downloading, installing, or using the Dipnot mobile application (the
+        "Application") in any way, you fully and unconditionally accept these
+        Terms of Use (the "Terms"). If you do not accept the Terms, please do
+        not use the Application.
+      </p>
 
       <h2>2. Description of the Service</h2>
-      <p>Dipnot is a mobile platform operating within the territory of the Republic of Turkey that publishes articles, news, guides, and video content in the field of scuba diving. Users can read, save, and obtain a personalised experience with the content free of charge.</p>
+      <p>
+        Dipnot is a mobile platform operating within the territory of the
+        Republic of Turkey that publishes articles, news, guides, and video
+        content in the field of scuba diving. Users can read, save, and obtain a
+        personalised experience with the content free of charge.
+      </p>
 
       <h2>3. Account Creation and Security</h2>
-      <p>To use the full functionality of the Application, you must create an account and provide accurate, current, and complete information (first name, last name, email, phone).</p>
+      <p>
+        To use the full functionality of the Application, you must create an
+        account and provide accurate, current, and complete information (first
+        name, last name, email, phone).
+      </p>
       <ul>
-        <li>Email verification is mandatory. Unverified accounts may have limited access or be deleted after a certain period.</li>
-        <li>You are solely responsible for the confidentiality of your account password and for all activities carried out under your account. Do not share your password with third parties.</li>
-        <li>If you notice unauthorised use of your account, notify help@dipnot.app immediately.</li>
+        <li>
+          Email verification is mandatory. Unverified accounts may have limited
+          access or be deleted after a certain period.
+        </li>
+        <li>
+          You are solely responsible for the confidentiality of your account
+          password and for all activities carried out under your account. Do not
+          share your password with third parties.
+        </li>
+        <li>
+          If you notice unauthorised use of your account, notify help@dipnot.app
+          immediately.
+        </li>
       </ul>
 
       <h2>4. User Obligations</h2>
-      <p>The following actions are strictly prohibited when using the Application:</p>
+      <p>
+        The following actions are strictly prohibited when using the
+        Application:
+      </p>
       <ul>
-        <li>Engaging in activities that could damage, overload, or exploit security vulnerabilities in the Application or its servers.</li>
-        <li>Sharing content (comments, profile information) that is unlawful, threatening, harassing, contains hate speech, encourages violence, or infringes the rights of others (intellectual property, privacy, etc.).</li>
-        <li>Attempting to access another user's account without authorisation, or stealing passwords or security tokens.</li>
-        <li>Reverse-engineering the Application, extracting or copying its source code.</li>
-        <li>Distributing spam, phishing, or malware through the Application.</li>
+        <li>
+          Engaging in activities that could damage, overload, or exploit
+          security vulnerabilities in the Application or its servers.
+        </li>
+        <li>
+          Sharing content (comments, profile information) that is unlawful,
+          threatening, harassing, contains hate speech, encourages violence, or
+          infringes the rights of others (intellectual property, privacy, etc.).
+        </li>
+        <li>
+          Attempting to access another user's account without authorisation, or
+          stealing passwords or security tokens.
+        </li>
+        <li>
+          Reverse-engineering the Application, extracting or copying its source
+          code.
+        </li>
+        <li>
+          Distributing spam, phishing, or malware through the Application.
+        </li>
       </ul>
-      <p>If you breach these obligations, Dipnot reserves the right to suspend or terminate your account temporarily or permanently.</p>
+      <p>
+        If you breach these obligations, Dipnot reserves the right to suspend or
+        terminate your account temporarily or permanently.
+      </p>
 
       <h2>5. Intellectual Property Rights</h2>
       <ul>
-        <li>Unless otherwise stated, all content of the Dipnot application (articles, images, videos, logos, graphics, software code, design) belongs to Dipnot or its licensors and is protected by international copyright, trademark, and intellectual property laws.</li>
-        <li>You may view and save the content for your personal, non-commercial use. <strong>However, you may not copy, distribute, republish, sell, or use it commercially without authorisation.</strong></li>
-        <li>The name "Dipnot" and the logo are a pending registered trademark. Their use requires written permission.</li>
+        <li>
+          Unless otherwise stated, all content of the Dipnot application
+          (articles, images, videos, logos, graphics, software code, design)
+          belongs to Dipnot or its licensors and is protected by international
+          copyright, trademark, and intellectual property laws.
+        </li>
+        <li>
+          You may view and save the content for your personal, non-commercial
+          use.
+          <strong
+            >However, you may not copy, distribute, republish, sell, or use it
+            commercially without authorisation.</strong
+          >
+        </li>
+        <li>
+          The name "Dipnot" and the logo are a pending registered trademark.
+          Their use requires written permission.
+        </li>
       </ul>
 
       <h2>6. User-Generated Content (UGC)</h2>
-      <p>If content sharing is enabled in future versions of the Application (for example, a comments or community section):</p>
+      <p>
+        If content sharing is enabled in future versions of the Application (for
+        example, a comments or community section):
+      </p>
       <ul>
-        <li>The copyright of content you share remains yours; however, you grant Dipnot the right to use, reproduce, distribute, and process that content within the Application for an unlimited period.</li>
-        <li>You are legally responsible for the content you share. Dipnot reserves the right to remove inappropriate content.</li>
+        <li>
+          The copyright of content you share remains yours; however, you grant
+          Dipnot the right to use, reproduce, distribute, and process that
+          content within the Application for an unlimited period.
+        </li>
+        <li>
+          You are legally responsible for the content you share. Dipnot reserves
+          the right to remove inappropriate content.
+        </li>
       </ul>
 
       <h2>7. Modification and Termination of the Service</h2>
       <p>Dipnot may, at any time, with or without prior notice:</p>
       <ul>
-        <li>Temporarily or permanently suspend or modify all or part of the Application.</li>
+        <li>
+          Temporarily or permanently suspend or modify all or part of the
+          Application.
+        </li>
         <li>Restrict access to specific features.</li>
         <li>Suspend or terminate your account if you breach these Terms.</li>
       </ul>
-      <p>Dipnot is not liable to pay any compensation in case the Application is suspended or your account is deleted.</p>
+      <p>
+        Dipnot is not liable to pay any compensation in case the Application is
+        suspended or your account is deleted.
+      </p>
 
       <h2>8. Limitation of Liability</h2>
       <ul>
-        <li>Dipnot does not warrant that the Application will be uninterrupted, error-free, secure, or virus-free. The Application is provided "as is" and "as available".</li>
-        <li>Dipnot shall not be held liable for any direct, indirect, incidental, special, or consequential damages (including loss of profit, data loss, reputational damage) that may arise from use or inability to use the Application.</li>
-        <li>Except where required by applicable mandatory law, Dipnot's total liability shall not exceed the fees you paid for the Application in the last 12 months (if any). As Dipnot is a free application, liability is deemed to be zero (0) TRY.</li>
+        <li>
+          Dipnot does not warrant that the Application will be uninterrupted,
+          error-free, secure, or virus-free. The Application is provided "as is"
+          and "as available".
+        </li>
+        <li>
+          Dipnot shall not be held liable for any direct, indirect, incidental,
+          special, or consequential damages (including loss of profit, data
+          loss, reputational damage) that may arise from use or inability to use
+          the Application.
+        </li>
+        <li>
+          Except where required by applicable mandatory law, Dipnot's total
+          liability shall not exceed the fees you paid for the Application in
+          the last 12 months (if any). As Dipnot is a free application,
+          liability is deemed to be zero (0) TRY.
+        </li>
       </ul>
 
       <h2>9. Third-Party Links and Services</h2>
-      <p>The Application may contain links to third-party websites such as WordPress. Dipnot is not responsible for the privacy practices or content of those sites. Clicking on such links is entirely at your own risk.</p>
+      <p>
+        The Application may contain links to third-party websites such as
+        WordPress. Dipnot is not responsible for the privacy practices or
+        content of those sites. Clicking on such links is entirely at your own
+        risk.
+      </p>
 
       <h2>10. Changes to the Terms</h2>
-      <p>Dipnot reserves the right to change these Terms at any time. Significant changes will be announced through the following channels:</p>
+      <p>
+        Dipnot reserves the right to change these Terms at any time. Significant
+        changes will be announced through the following channels:
+      </p>
       <ul>
         <li>In-app notification (at least 7 days in advance)</li>
         <li>Notification sent to your registered email address</li>
       </ul>
-      <p>Continuing to use the Application after the changes take effect means you accept the new Terms.</p>
+      <p>
+        Continuing to use the Application after the changes take effect means
+        you accept the new Terms.
+      </p>
 
       <h2>11. Governing Law and Jurisdiction</h2>
-      <p>These Terms are governed by the laws of the Republic of Turkey. For any dispute arising out of or relating to these Terms, the Courts and Enforcement Offices of Istanbul (Çağlayan) shall have jurisdiction.</p>
+      <p>
+        These Terms are governed by the laws of the Republic of Turkey. For any
+        dispute arising out of or relating to these Terms, the Courts and
+        Enforcement Offices of Istanbul (Çağlayan) shall have jurisdiction.
+      </p>
 
       <h2>12. Contact</h2>
-      <p>For any questions, complaints, or suggestions about these Terms or the Application, you can contact us at:</p>
+      <p>
+        For any questions, complaints, or suggestions about these Terms or the
+        Application, you can contact us at:
+      </p>
       <p>
         <span class="icon mr-2">
           <i class="fa-solid fa-envelope"></i>
@@ -117,5 +235,4 @@ og:
       </p>
     </div>
   </section>
-
 </main>


### PR DESCRIPTION
## Summary

- Runs `prettier --write .` over the 13 files `format:check` was flagging after [#73](https://github.com/Dipnot-App/www.dipnot.app/pull/73) landed the tooling. Mechanical reformat — no semantic diffs.
- One coupled layout fix to [`_includes/layouts/base.njk`](_includes/layouts/base.njk) — Prettier's unavoidable blank line after YAML frontmatter combined with the old 2-space indent before `{{ content \| safe }}` produced a trailing-whitespace line in every rendered page, tripping `html-validate`'s hard gate. Left-aligning the expression clears it; rendered HTML whitespace is inconsequential.
- Bumped `cssVersion` + `jsVersion` to `260425_1` to cache-bust the reformatted `css/styles.css` + `js/*.js`.

## Files reformatted (13)

- HTML pages: [`404.html`](404.html), [`brand-book.html`](brand-book.html), [`index.html`](index.html)
- Legal pages: [`gizlilik-politikasi.html`](gizlilik-politikasi.html), [`privacy-policy.html`](privacy-policy.html), [`kullanim-kosullari.html`](kullanim-kosullari.html), [`terms-of-use.html`](terms-of-use.html)
- JS: [`js/main.js`](js/main.js), [`js/contact.js`](js/contact.js), [`js/newsletter.js`](js/newsletter.js)
- CSS: [`css/styles.css`](css/styles.css)
- Other: [`CHANGELOG.md`](CHANGELOG.md), [`site.webmanifest`](site.webmanifest)

## Incidental fixes Prettier caught

- `css/styles.css` — stray `;;` (`rgba(...);;` → `rgba(...);`) in `.menu-list li:hover`.
- `css/styles.css` — missing trailing newline.
- Various HTML `style=""` attributes lost their trailing `;` (Prettier's HTML attribute-style default).
- Hex colors lowercased (`#37525E` → `#37525e`).

## Test plan

- [x] `npx prettier --check .` — clean after reformat.
- [x] `npm run build` — Eleventy builds 7 pages successfully.
- [x] `npm run check:html` — clean after the `base.njk` indent fix.
- [ ] Pa11y + Lighthouse — soft gates in CI; expect no regression.
- [ ] Visual spot-check in the deployed preview (`dev` branch doesn't deploy; after merge to `main`): Turkish characters render correctly in legal pages, hero + about sections on `index.html` look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)