### PR TITLE
Bump, npm audit threshold to critical

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check:links": "lychee --no-progress _site",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "audit": "npm audit --audit-level=high"
+    "audit": "npm audit --audit-level=critical"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",


### PR DESCRIPTION
## Summary

- Flip `package.json` → `"audit": "npm audit --audit-level=critical"` (was `high`).
- Acts on the core_docs ack in `to-landing.md` (2026-04-25): Nev approved option (a) on the audit-level variance.
- Variance is ratified upstream in core_docs PR [#100](https://github.com/Dipnot-App/core_docs/pull/100) (`code-quality.md` → Variances).

## Why

The three accepted dev-dep advisories (lodash `_.template`, lodash `_.unset`/`_.omit`, tmp symlink) sit under transitive deps of `pa11y-ci` / `@lhci/cli`. They're unreachable with our inputs and have no upstream fix. `--audit-level=high` left `npm audit` permanently red — alarm fatigue. `critical` still flags any new critical CVE, which is the signal that actually matters.

The "Accepted dev-dep vulnerabilities" table in landing's `CLAUDE.md` stays as the authoritative record of *why* the threshold is bumped. If/when upstream ships compatible fixes, drop the row and revisit whether the variance is still needed.

## Test plan

- [x] `npm run audit` → exits 0 locally (8 below-threshold advisories still listed, none critical)
- [ ] CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)