### PR TITLE
Add, hero entrance animation with rising bubbles

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
-  "cssVersion": "260425_1",
+  "cssVersion": "260513_1",
   "jsVersion": "260425_1",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",

--- a/css/styles.css
+++ b/css/styles.css
@@ -53,6 +53,121 @@ h6,
   background-image: linear-gradient(92deg, #37525e 20%, #89a3b3 100%);
 }
 
+/* ---------- Hero entrance animation ---------- */
+
+.hero-animated {
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-animated .hero-body {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-animated .hero-body > .columns > .column {
+  opacity: 0;
+  transform: translateY(28px);
+  animation: hero-rise 900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.hero-animated .hero-body > .columns > .column:nth-child(1) {
+  animation-delay: 200ms;
+}
+
+.hero-animated .hero-body > .columns > .column:nth-child(2) {
+  animation-delay: 450ms;
+}
+
+@keyframes hero-rise {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* "okumaya" highlight pulse once after the title settles */
+.hero-animated .title .has-text-primary {
+  display: inline-block;
+  animation: okumaya-pulse 1.8s ease-out 1.3s 1;
+}
+
+@keyframes okumaya-pulse {
+  0%,
+  100% {
+    text-shadow: 0 0 0 transparent;
+  }
+  50% {
+    text-shadow: 0 0 18px rgba(4, 209, 178, 0.65);
+  }
+}
+
+/* Decorative rising bubbles */
+.hero-bubbles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-bubbles span {
+  position: absolute;
+  bottom: -40px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 255, 255, 0.35),
+    rgba(255, 255, 255, 0.08) 60%,
+    transparent 72%
+  );
+  box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.18);
+  opacity: 0;
+  animation: bubble-rise linear infinite;
+  will-change: transform, opacity;
+}
+
+.hero-bubbles span:nth-child(1) { left:  8%; width: 56px; height: 56px; animation-duration: 16s; animation-delay: 0s;   }
+.hero-bubbles span:nth-child(2) { left: 22%; width: 38px; height: 38px; animation-duration: 13s; animation-delay: 3s;   }
+.hero-bubbles span:nth-child(3) { left: 36%; width: 72px; height: 72px; animation-duration: 20s; animation-delay: 6s;   }
+.hero-bubbles span:nth-child(4) { left: 52%; width: 44px; height: 44px; animation-duration: 15s; animation-delay: 1.5s; }
+.hero-bubbles span:nth-child(5) { left: 68%; width: 62px; height: 62px; animation-duration: 18s; animation-delay: 4s;   }
+.hero-bubbles span:nth-child(6) { left: 82%; width: 34px; height: 34px; animation-duration: 12s; animation-delay: 2s;   }
+.hero-bubbles span:nth-child(7) { left: 92%; width: 48px; height: 48px; animation-duration: 17s; animation-delay: 5.5s; }
+
+@keyframes bubble-rise {
+  0% {
+    transform: translate3d(0, 0, 0);
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.65;
+  }
+  50% {
+    transform: translate3d(18px, -55vh, 0);
+    opacity: 0.85;
+  }
+  90% {
+    opacity: 0.3;
+  }
+  100% {
+    transform: translate3d(-12px, -110vh, 0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-animated .hero-body > .columns > .column,
+  .hero-animated .title .has-text-primary {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .hero-bubbles {
+    display: none;
+  }
+}
+
 .menu-list li:hover a,
 #features .card:hover .icon,
 #faq .card:hover .card-header,

--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@ hasContactForm: true
 ---
 
 <!-- HERO BANNER -->
-<section class="hero is-fullheight-with-navbar has-background-hero">
+<section class="hero is-fullheight-with-navbar has-background-hero hero-animated">
+  <div class="hero-bubbles" aria-hidden="true">
+    <span></span><span></span><span></span><span></span>
+    <span></span><span></span><span></span>
+  </div>
   <div class="hero-body">
     <div class="columns">
       <div class="column is-align-content-center">


### PR DESCRIPTION
## Summary

- Decorative CSS-only rising bubbles in the hero background (7 bubbles, varied size/speed, 12–20s loops, infinite).
- One-time fade + 28px rise on the hero's title/CTA column and device-image column, staggered (200ms / 450ms).
- One-shot teal glow pulse on the highlighted "okumaya" once the title settles (~1.3s).
- All animations disabled under `prefers-reduced-motion: reduce`; bubbles hidden entirely.
- No JS added; CSS cache-bust bumped (`260425_1` → `260513_1`).

## Test plan

- [ ] `npm run serve` — hero loads, bubbles drift up continuously, columns rise into place once.
- [ ] Toggle OS "reduce motion" → animations stop, no bubbles, content visible immediately.
- [ ] `npm run check:html` passes.
- [ ] `npm run check:a11y` passes (bubbles are `aria-hidden`).
- [ ] Lighthouse check doesn't regress perf score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)