### PR TITLE
Fix, restore CI by removing stray newline in App Store href

### DIFF
--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -118,8 +118,7 @@
               <img src="/img/svg/google-play.svg" alt="Google Play">
               <span class="ml-2">Google Play</span>
             </a>
-            <a href="https://apps.apple.com/app/id6757102330
-" target="_blank" class="button is-light is-rounded">
+            <a href="https://apps.apple.com/app/id6757102330" target="_blank" rel="noopener noreferrer" class="button is-light is-rounded">
               <img src="/img/svg/app-store.svg" alt="App Store">
               <span class="ml-2">App Store</span>
             </a>

--- a/_includes/partials/nav.njk
+++ b/_includes/partials/nav.njk
@@ -61,8 +61,7 @@
               <img src="/img/svg/google-play.svg" alt="Google Play">
               <span class="ml-2">Google Play</span>
             </a>
-            <a href="https://apps.apple.com/app/id6757102330
-" target="_blank" class="button is-light is-rounded">
+            <a href="https://apps.apple.com/app/id6757102330" target="_blank" rel="noopener noreferrer" class="button is-light is-rounded">
               <img src="/img/svg/app-store.svg" alt="App Store">
               <span class="ml-2">App Store</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -35,8 +35,7 @@ hasContactForm: true
             <img src="/img/svg/google-play.svg" alt="Google Play" />
             <span class="ml-2">Google Play</span>
           </a>
-          <a href="https://apps.apple.com/app/id6757102330
-" target="_blank" class="button is-light is-rounded">
+          <a href="https://apps.apple.com/app/id6757102330" target="_blank" rel="noopener noreferrer" class="button is-light is-rounded">
             <img src="/img/svg/app-store.svg" alt="App Store" />
             <span class="ml-2">App Store</span>
           </a>
@@ -348,8 +347,7 @@ hasContactForm: true
           <img src="/img/svg/google-play.svg" alt="Google Play" />
           <span class="ml-2">Google Play</span>
         </a>
-        <a href="https://apps.apple.com/app/id6757102330
-" target="_blank" class="button is-light is-rounded">
+        <a href="https://apps.apple.com/app/id6757102330" target="_blank" rel="noopener noreferrer" class="button is-light is-rounded">
           <img src="/img/svg/app-store.svg" alt="App Store" />
           <span class="ml-2">App Store</span>
       </a>


### PR DESCRIPTION
## Summary
- Strip the embedded newline inside the App Store `href` attribute in [nav.njk:64](_includes/partials/nav.njk#L64), [footer.njk:121](_includes/partials/footer.njk#L121), and two spots in [index.html](index.html) (lines 38 and 351). `html-validate` was rejecting all 7 pages with `attribute-allowed-values`, breaking CI on the last `dev` push (run [25857955771](https://github.com/Dipnot-App/www.dipnot.app/actions/runs/25857955771)).
- Add `rel="noopener noreferrer"` to the same four App Store anchors. CLAUDE.md mandates it for every `target="_blank"` and they were missing it.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run check:html` passes locally (was 15 errors → 0)
- [ ] CI green on this PR

## Notes
- Pre-existing drift not fixed here (flagging for a follow-up): the **Google Play** anchors in [nav.njk:60](_includes/partials/nav.njk#L60), [index.html:31](index.html#L31), and [index.html:344](index.html#L344) are also missing `rel="noopener noreferrer"`. Footer's Google Play link already has it. Happy to fix in a follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)