### PR TITLE
Rewrite brand-book.html to match ratified core_docs tokens

### DIFF
--- a/brand-book.html
+++ b/brand-book.html
@@ -15,6 +15,10 @@ og:
     <div class="columns">
       <div class="column">
         <p class="title is-size-1 has-text-white mb-5">Brand Book</p>
+        <p class="subtitle has-text-white">
+          A curated public reference for using the Dipnot brand
+          consistently — logo, color, type, and usage rules.
+        </p>
       </div>
     </div>
   </div>
@@ -22,57 +26,142 @@ og:
 
 <!-- MAIN PAGE -->
 <main class="container py-6">
-  <a
-    href="https://app.gingersauce.co/my/view-new-v3/72228"
-    target="_blank"
-    rel="noopener noreferrer"
-    >Dipnot Brand Book by Gingersauce</a
-  >
+  <p class="text-small mb-5">
+    Full internal brand specification (extended):
+    <a
+      href="https://app.gingersauce.co/my/view-new-v3/72228"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Dipnot Brand Book by Gingersauce</a
+    >
+  </p>
 
   <!-- LOGO CONTENT -->
   <section class="section">
     <div class="content">
-      <h2>Logo Versions</h2>
+      <h2>Logo</h2>
+      <p>
+        The Dipnot mark comes in <strong>solo marks</strong>
+        (transparent background, for in-layout use) and
+        <strong>composed variants</strong> (mark on a solid background,
+        for app icons, OG cards, and social avatars). Pick the variant
+        that reads cleanly against its background.
+      </p>
     </div>
 
-    <div class="columns has-background-white">
-      <div class="column">
+    <h3 class="title is-size-5 mt-5">Solo marks</h3>
+    <div class="columns is-multiline">
+      <div class="column is-one-third">
         <div class="box has-background-white">
-          <figure class="has-text-centered p-6">
-            <img
-              src="/img/logos/logo.svg"
-              class="has-text-centered"
-              alt="Logo"
-              width="200"
-            />
+          <figure class="has-text-centered p-5">
+            <img src="/img/logos/logo.svg" alt="Dipnot teal logo" width="160" />
           </figure>
+          <p class="has-text-centered text-small">
+            <strong>Default</strong> · Teal <code>#338596</code><br />
+            Reader-facing surfaces and the admin panel.
+          </p>
         </div>
       </div>
 
-      <div class="column">
+      <div class="column is-one-third">
         <div class="box has-background-white">
-          <figure class="has-text-centered p-6">
+          <figure class="has-text-centered p-5">
             <img
               src="/img/logos/logo-gold.svg"
-              class="has-text-centered"
-              alt="Logo"
-              width="200"
+              alt="Dipnot gold logo"
+              width="160"
             />
           </figure>
+          <p class="has-text-centered text-small">
+            <strong>Gold</strong> · <code>#C49B3A</code><br />
+            Admin / operator contexts.
+          </p>
         </div>
       </div>
 
+      <div class="column is-one-third">
+        <div class="box" style="background-color: #131b26">
+          <figure class="has-text-centered p-5">
+            <img
+              src="/img/logos/logo-white.svg"
+              alt="Dipnot white logo"
+              width="160"
+            />
+          </figure>
+          <p class="has-text-centered text-small has-text-white">
+            <strong>White</strong> · <code>#FFFFFF</code><br />
+            Dark or photographic backgrounds.
+          </p>
+        </div>
+      </div>
+
+      <div class="column is-one-third">
+        <div class="box has-background-white">
+          <figure class="has-text-centered p-5">
+            <img
+              src="/img/logos/logo-black.svg"
+              alt="Dipnot black logo"
+              width="160"
+            />
+          </figure>
+          <p class="has-text-centered text-small">
+            <strong>Black</strong> · <code>#000000</code><br />
+            Light backgrounds, print, low-ink.
+          </p>
+        </div>
+      </div>
+
+      <div class="column is-one-third">
+        <div class="box has-background-white">
+          <figure class="has-text-centered p-5">
+            <img
+              src="/img/logos/logo-winter-bloom.svg"
+              alt="Dipnot Winter Bloom logo"
+              width="160"
+            />
+          </figure>
+          <p class="has-text-centered text-small">
+            <strong>Winter Bloom</strong> · <code>#2E162C</code><br />
+            Deep-plum monochrome; pairs with warm or pale backgrounds.
+          </p>
+        </div>
+      </div>
+
+      <div class="column is-one-third">
+        <div class="box has-background-white">
+          <figure class="has-text-centered p-5">
+            <img
+              src="/img/logos/logo-sky-captain.svg"
+              alt="Dipnot Sky Captain logo"
+              width="160"
+            />
+          </figure>
+          <p class="has-text-centered text-small">
+            <strong>Sky Captain</strong> · <code>#131B26</code><br />
+            Near-black navy monochrome; pairs with bright backgrounds.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <h3 class="title is-size-5 mt-5">Composed variants</h3>
+    <p class="content">
+      Solid background + mark, with a baked-in 1/6-tile clear-space
+      border. Use for app icons, OG cards, and social avatars — don't
+      add extra padding around them.
+    </p>
+    <div class="columns">
       <div class="column">
         <div class="box" style="background-color: #338596">
           <figure class="has-text-centered">
             <img
               src="/img/logos/logo-white-on-teal.svg"
-              class="has-text-centered"
-              alt="Logo"
-              width="280"
+              alt="White Dipnot mark on teal"
+              width="240"
             />
           </figure>
         </div>
+        <p class="has-text-centered text-small">White on Teal</p>
       </div>
 
       <div class="column">
@@ -80,12 +169,25 @@ og:
           <figure class="has-text-centered">
             <img
               src="/img/logos/logo-white-on-sky-captain.svg"
-              class="has-text-centered"
-              alt="Logo"
-              width="280"
+              alt="White Dipnot mark on Sky Captain"
+              width="240"
             />
           </figure>
         </div>
+        <p class="has-text-centered text-small">White on Sky Captain</p>
+      </div>
+
+      <div class="column">
+        <div class="box" style="background-color: #131b26">
+          <figure class="has-text-centered">
+            <img
+              src="/img/logos/logo-teal-on-sky-captain.svg"
+              alt="Teal Dipnot mark on Sky Captain"
+              width="240"
+            />
+          </figure>
+        </div>
+        <p class="has-text-centered text-small">Teal on Sky Captain</p>
       </div>
     </div>
   </section>
@@ -94,65 +196,168 @@ og:
   <section class="section">
     <div class="content">
       <h2>Colors</h2>
+      <p>
+        <strong>Dipnot Teal</strong> is the single primary accent
+        across every surface — buttons, active states, focus rings,
+        links. The two darker tones below are
+        <strong>composed-asset backgrounds only</strong> (app icons,
+        OG cards) — never use them as UI backgrounds.
+      </p>
     </div>
 
     <div class="columns">
       <div class="column">
-        <div class="box has-text-white" style="background-color: #348698">
-          <h3>Algiers Blue</h3>
-          <p>Hex #348698</p>
-          <p>RGB 52 134 152</p>
-          <p>CMYK 66 12 0 40</p>
-          <p>Pantone 293C</p>
+        <div class="box has-text-white" style="background-color: #338596">
+          <h3 class="has-text-white">Dipnot Teal</h3>
+          <p class="text-small">
+            Hex #338596<br />
+            RGB 51 133 150<br />
+            oklch(0.547 0.076 210)<br />
+            <em>Primary accent — all surfaces</em>
+          </p>
         </div>
       </div>
 
       <div class="column">
         <div class="box has-text-white" style="background-color: #131b26">
-          <h3>Sky Captain</h3>
-          <p>Hex #131B26</p>
-          <p>RGB 19 27 38</p>
-          <p>CMYK 50 29 0 85</p>
-          <p>Pantone 5605C</p>
+          <h3 class="has-text-white">Sky Captain</h3>
+          <p class="text-small">
+            Hex #131B26<br />
+            RGB 19 27 38<br />
+            CMYK 50 29 0 85 · Pantone 5605C<br />
+            <em>Composed-asset background only</em>
+          </p>
         </div>
       </div>
 
       <div class="column">
         <div class="box has-text-white" style="background-color: #2e162c">
-          <h3>Winter Bloom</h3>
-          <p>Hex #2E162C</p>
-          <p>RGB 46 22 44</p>
-          <p>CMYK 0 52 4 82</p>
-          <p>Pantone 643C</p>
+          <h3 class="has-text-white">Winter Bloom</h3>
+          <p class="text-small">
+            Hex #2E162C<br />
+            RGB 46 22 44<br />
+            CMYK 0 52 4 82 · Pantone 643C<br />
+            <em>Composed-asset background only</em>
+          </p>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- TYPOGRAFI CONTENT -->
+  <!-- TYPOGRAPHY CONTENT -->
   <section class="section">
     <div class="content">
       <h2>Typography</h2>
+      <p>
+        One sans family across every surface for titles and web body:
+        <strong>Inter</strong> (SIL OFL 1.1, free). The brand wordmark
+        uses a separate display font, <strong>Gabarito</strong>
+        Semibold — baked into the logo SVGs and never loaded at
+        runtime.
+      </p>
     </div>
 
     <div class="columns">
-      <div class="column">
-        <div class="box has-text-centered" style="background-color: #131b26">
-          Primary Font
-          <br />
-          Inter
-          <br />
-          Aa
+      <div class="column is-half">
+        <div class="box has-text-centered p-6" style="background-color: #131b26">
+          <p class="has-text-white text-small">Primary UI font</p>
+          <p
+            class="has-text-white"
+            style="font-family: 'Inter', sans-serif; font-size: 4rem"
+          >
+            Aa
+          </p>
+          <p class="has-text-white title is-size-4">Inter</p>
+          <p class="has-text-white text-small">
+            Titles &amp; body · weights 400 / 500 / 600 / 700
+          </p>
+        </div>
+      </div>
+
+      <div class="column is-half">
+        <div class="box has-text-centered p-6" style="background-color: #338596">
+          <p class="has-text-white text-small">Wordmark only (not runtime)</p>
+          <p class="has-text-white" style="font-size: 4rem">Aa</p>
+          <p class="has-text-white title is-size-4">Gabarito</p>
+          <p class="has-text-white text-small">
+            Semibold 600 · outlined in logo artwork
+          </p>
         </div>
       </div>
     </div>
   </section>
 
   <!-- RULES CONTENT -->
-  <section class="section"></section>
+  <section class="section">
+    <div class="content">
+      <h2>Rules</h2>
+
+      <h3>Clear space</h3>
+      <p>
+        Leave <strong>at least 1/6 of the mark height</strong> empty on
+        all sides of any solo mark. No text, button, or container edge
+        may enter this zone. If the mark renders at 60 px, keep 10 px
+        clear on each side. Clear space is a minimum, not a target —
+        more is fine, less is not. Composed variants already bake in
+        the equivalent padding; don't add more around them.
+      </p>
+
+      <h3>Minimum size</h3>
+      <p>
+        The mark holds up small, but inner detail muddies below 16 px.
+        Floors per context:
+      </p>
+      <table class="table is-bordered is-fullwidth">
+        <thead>
+          <tr>
+            <th>Context</th>
+            <th>Minimum</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Favicon / browser tab</td>
+            <td>16 × 16 px</td>
+          </tr>
+          <tr>
+            <td>Inline UI (button icon, nav item, chip)</td>
+            <td>20 × 20 px</td>
+          </tr>
+          <tr>
+            <td>Standalone UI (avatar, card corner, list row)</td>
+            <td>40 × 40 px</td>
+          </tr>
+          <tr>
+            <td>Display (hero, splash, marketing)</td>
+            <td>80 × 80 px</td>
+          </tr>
+          <tr>
+            <td>Print</td>
+            <td>8 mm</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
   <!-- MISUSE CONTENT -->
-  <section class="section"></section>
+  <section class="section">
+    <div class="content">
+      <h2>Misuse</h2>
+      <p>Don't:</p>
+      <ul>
+        <li>Stretch or skew the mark.</li>
+        <li>Recolor outside the approved palette.</li>
+        <li>Add shadows, glows, or outlines.</li>
+        <li>Place the mark on low-contrast backgrounds.</li>
+        <li>Rotate or flip the mark.</li>
+        <li>
+          Use the Winter Bloom or Sky Captain colors as UI backgrounds
+          — they exist only for composed brand assets.
+        </li>
+      </ul>
+    </div>
+  </section>
 
   <!-- Vision/Mission CONTENT -->
   <section class="section">
@@ -162,8 +367,8 @@ og:
           <div class="content">
             <div class="h3">Vision</div>
             <p>
-              To become the most trusted and enduring source of knowledge for
-              the underwater world.
+              To become the most trusted and enduring source of
+              knowledge for the underwater world.
             </p>
           </div>
         </div>
@@ -174,15 +379,12 @@ og:
           <div class="content">
             <div class="h3">Mission</div>
             <p>
-              To deliver clear, reliable, and well-crafted content about diving
-              and the underwater world, accessible to all levels.
+              To deliver clear, reliable, and well-crafted content about
+              diving and the underwater world, accessible to all levels.
             </p>
           </div>
         </div>
       </div>
     </div>
   </section>
-
-  <!-- Brand Archetype CONTENT -->
-  <section class="section"></section>
 </main>


### PR DESCRIPTION
Execution of #53 (epic #31). Brings the public brand book in line with the ratified brand language in `core_docs/product-design/`.

## Scope decisions (issue #21)

| Decision | Chosen | Note |
|---|---|---|
| Language | **Fully English** | Partner/press-facing audience |
| Public scope | **Curated subset** | Full OKLCH/chart palette omitted per #47 — err on less for v1 |
| Gingersauce link | **Kept** | Nev's call — diverges from #53's "drop" recommendation; relabeled as the extended internal spec |

## Changes

- **Logo** — full ratified set: 6 solo marks + 3 composed variants, each labeled with color + intended use (from `logo.md`).
- **Colors** — stale *Algiers Blue `#348698`* replaced with ratified **Dipnot Teal `#338596`** (correct RGB 51 133 150 / oklch). Sky Captain + Winter Bloom kept but relabeled *composed-asset backgrounds only*.
- **Typography** — Inter as the single UI family; Gabarito noted as wordmark-only (never loaded at runtime).
- **Rules** — was empty; filled with clear-space (1/6 mark height) + per-context minimum-size table.
- **Misuse** — was empty; filled with the six don'ts from `logo.md`.
- **Brand Archetype** — dropped. `core_docs/product-design/voice.md` has no ratified archetype (33 lines, tone table only). Escalated via `core_docs/communication/to-core-docs.md`; section returns when voice.md gains one.

## Verification

- `npm run build` ✅
- `npm run check:html` ✅ (exit 0 — hard CI gate)

Closes #53. Resolves #21 (decisions recorded above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)