### PR TITLE
Remove unused --color-logo CSS token

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
-  "cssVersion": "260513_1",
+  "cssVersion": "260515_1",
   "jsVersion": "260425_1",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,5 +1,4 @@
 :root {
-  --color-logo: #338596;
   --color-primary: #04d1b2;
 }
 


### PR DESCRIPTION
`--color-logo: #338596` was defined in `:root` but referenced **nowhere** in the repo (verified across css / html / njk / js). Dead token — removed. No visual change.

`--color-primary: #04d1b2` is **left untouched** — it's still used by the hover-accent rule on feature-card icons / FAQ headers / footer menu links. Its divergence from the brand book's `#338596` is a deferred decision, already tracked as a checkbox under epic #31.

Cache-bust: `cssVersion` 260513_1 → 260515_1.

## Verification
- `npm run build` ✅
- `npm run check:html` ✅ (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)