### PR TITLE
Bump CI Node 20 → 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Bump [.github/workflows/ci.yml:29](.github/workflows/ci.yml#L29) `node-version` from `20` to `22`.
- Node 20 reached EOL 2026-04; we're past it. Active LTS is now 22.
- Unblocks [Dependabot PR #86](https://github.com/Dipnot-App/www.dipnot.app/pull/86) (`html-validate` 10.16 → 11.2), which currently fails on Node 20 with `TypeError: fs.globSync is not a function` — `html-validate` 11.1.0 [replaced its `glob` dep with the Node-native `fs.globSync`](https://gitlab.com/html-validate/html-validate/-/blob/master/CHANGELOG.md), available only on Node 22+.

## Risk

Low. Only the CI workflow file changes. No package.json `engines` pin existed, no `.nvmrc`. The other two bumps in #86 (`pa11y-ci`, `wait-on`) are patches.

## Test plan

- [ ] CI green on this PR — every check uses Node 22.
- [ ] After merge: comment `@dependabot rebase` on #86, confirm `Build & check` passes there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)