### PR TITLE
Account-deletion flow: public page, confirm page, App Check (#92)

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -2,7 +2,7 @@
   "title": "Dipnot",
   "baseUrl": "https://dipnot.app",
   "cssVersion": "260515_1",
-  "jsVersion": "260425_1",
+  "jsVersion": "260602_1",
   "themeColor": "#338596",
   "author": "Nevcan Uludaş",
   "ogImage": "https://dipnot.app/img/og/og-default.png",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -71,5 +71,8 @@
   {%- if hasContactForm %}
   <script src="/js/contact.js?v={{ site.jsVersion }}"></script>
   {%- endif %}
+  {%- if pageModule %}
+  <script type="module" src="/js/{{ pageModule }}?v={{ site.jsVersion }}"></script>
+  {%- endif %}
 </body>
 </html>

--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -156,7 +156,7 @@
 
     <div class="columns mt-6">
       <div class="column has-text-centered">
-        Copyright &copy; 2025&ndash;2026 <span class="mx-4">|</span> <a href="/gizlilik-politikasi.html">Gizlilik politikası</a> <span class="mx-4">|</span> <a href="/kullanim-kosullari.html">Kullanım koşulları</a>
+        Copyright &copy; 2025&ndash;2026 <span class="mx-4">|</span> <a href="/gizlilik-politikasi.html">Gizlilik politikası</a> <span class="mx-4">|</span> <a href="/kullanim-kosullari.html">Kullanım koşulları</a> <span class="mx-4">|</span> <a href="/hesap-silme.html">Hesap silme</a>
         <br>
         Website <a href="https://vacstudio.com/" target="_blank" rel="noopener noreferrer">V.A.C. Studio</a> tarafından geliştirilmiştir.
       </div>

--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -39,7 +39,7 @@ og:
       <h1>Gizlilik Politikası ve Aydınlatma Metni (KVKK)</h1>
       <p>
         <strong>Son Güncelleme:</strong>
-        <time datetime="2026-04-24">24 Nisan 2026</time>
+        <time datetime="2026-06-02">2 Haziran 2026</time>
       </p>
 
       <h2>1. Veri Sorumlusu ve Temsilcisi</h2>
@@ -172,6 +172,19 @@ og:
             europe-west1) işlenmektedir.</span
           >
         </li>
+        <li>
+          <strong>Brevo (Sendinblue SAS – Avrupa Birliği):</strong>
+          <br />
+          <span
+            >Hesap silme talebinizi doğrulamak amacıyla size gönderilen tek
+            kullanımlık onay bağlantısı Brevo'nun transactional e-posta servisi
+            üzerinden iletilir; bu kapsamda yalnızca e-posta adresiniz işlenir.
+            Verileriniz Brevo'nun Avrupa Birliği'ndeki sunucularında (Fransa /
+            Almanya – OVH ve Google Cloud Belçika) barındırılır. Sınırlı sayıda
+            alt-işleyici aracılığıyla ABD / Hindistan'a yapılabilecek aktarımlar
+            uygun güvencelerle (standart sözleşme hükümleri) korunur.</span
+          >
+        </li>
       </ul>
       <p>
         Yurt dışına aktarım söz konusu olduğunda, KVKK'nın 9. maddesi uyarınca
@@ -236,6 +249,11 @@ og:
         Bu haklarınızı kullanmak için help@dipnot.app adresine kimlik tespiti
         sağlayacak bilgilerle başvuruda bulunabilirsiniz. Başvurularınız en kısa
         sürede (en geç 30 gün içinde) ücretsiz olarak cevaplandırılacaktır.
+      </p>
+      <p>
+        Hesabınızı ve verilerinizi silmek için uygulamaya giriş yapmadan
+        <a href="/hesap-silme.html">Hesap Silme</a> sayfasındaki formu da
+        kullanabilirsiniz.
       </p>
 
       <h2>7. Reklam ve Pazarlama E-postaları</h2>

--- a/hesap-silme-onayi.html
+++ b/hesap-silme-onayi.html
@@ -1,0 +1,54 @@
+---
+layout: base.njk
+lang: tr
+title: "Hesap Silme Onayı | Dipnot App"
+description: "Dipnot hesap silme talebinizi onaylayın."
+robots: "noindex, nofollow"
+pageModule: account-deletion-confirm.js
+og:
+  locale: tr_TR
+  url: "https://dipnot.app/hesap-silme-onayi.html"
+  description: "Dipnot hesap silme talebinizi onaylayın."
+---
+
+<!-- HERO BANNER -->
+<section class="hero has-background-hero">
+  <div class="hero-body">
+    <div class="columns">
+      <div class="column">
+        <p class="title is-size-1 has-text-white mb-5">
+          Hesap Silme <span class="has-text-primary">Onayı</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- MAIN PAGE -->
+<main class="container py-6">
+  <section class="section">
+    <div class="content">
+      <h1>Hesap Silme Talebini Onaylama</h1>
+
+      <div id="confirm-spinner" class="has-text-centered py-5">
+        <span class="icon is-large">
+          <i class="fas fa-spinner fa-spin fa-2x"></i>
+        </span>
+        <p class="mt-3">Talebiniz doğrulanıyor…</p>
+      </div>
+
+      <div
+        id="confirm-status"
+        class="notification is-hidden"
+        role="status"
+        aria-live="polite"
+      ></div>
+
+      <p>
+        Sorun yaşarsanız
+        <a href="/hesap-silme.html">silme talebini yeniden oluşturabilir</a>
+        veya help@dipnot.app adresinden bizimle iletişime geçebilirsiniz.
+      </p>
+    </div>
+  </section>
+</main>

--- a/hesap-silme.html
+++ b/hesap-silme.html
@@ -1,0 +1,140 @@
+---
+layout: base.njk
+lang: tr
+title: "Hesap Silme | Dipnot App"
+description: "Dipnot hesabınızı ve verilerinizi silme talebinde bulunun. Uygulamaya giriş yapmadan, e-posta adresinizle hesap silme talebi oluşturun."
+keywords: "dipnot, hesap silme, hesabımı sil, veri silme, kvkk"
+pageModule: account-deletion.js
+hreflang:
+  - lang: tr
+    href: "https://dipnot.app/hesap-silme.html"
+og:
+  locale: tr_TR
+  url: "https://dipnot.app/hesap-silme.html"
+  description: "Dipnot hesabınızı ve verilerinizi silme talebinde bulunun."
+---
+
+<!-- HERO BANNER -->
+<section class="hero has-background-hero">
+  <div class="hero-body">
+    <div class="columns">
+      <div class="column">
+        <p class="title is-size-1 has-text-white mb-5">
+          Hesap <span class="has-text-primary">Silme</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- MAIN PAGE -->
+<main class="container py-6">
+  <section class="section">
+    <div class="content">
+      <h1>Dipnot Hesabınızı Silme</h1>
+      <p>
+        Bu sayfa, <strong>Dipnot</strong> uygulaması (geliştirici:
+        <strong>Dipnot Uygulama Ekibi</strong>) hesabınızı ve ilişkili
+        verilerinizi silmeniz içindir. Uygulamayı kaldırmış veya giriş
+        yapamıyor olsanız bile, aşağıdaki formla
+        <strong>giriş yapmadan</strong> silme talebi oluşturabilirsiniz.
+      </p>
+
+      <h2>Hesap silme talebi nasıl oluşturulur?</h2>
+      <ol>
+        <li>
+          Aşağıdaki forma hesabınıza ait <strong>e-posta adresini</strong>
+          girin (isterseniz silme nedenini ekleyin).
+        </li>
+        <li><strong>"Silme talebi gönder"</strong> düğmesine tıklayın.</li>
+        <li>
+          E-posta adresinize gönderilen <strong>onay bağlantısına</strong>
+          tıklayarak talebinizi doğrulayın. Bu adım, başkasının sizin adınıza
+          talep oluşturmasını önler — talep, siz onaylayana kadar işleme
+          alınmaz.
+        </li>
+      </ol>
+
+      <h2>Uygulamadan silme (mevcut kullanıcılar)</h2>
+      <p>
+        Uygulamaya giriş yapabiliyorsanız hesabınızı doğrudan uygulama içinden
+        de silebilirsiniz:
+      </p>
+      <p>
+        <strong>Ayarlar → "Hesabımı Sil" → "Evet, Sil"</strong>
+      </p>
+      <p>
+        Bu işlem giriş kimliğinizi anında siler; profil verileriniz aşağıda
+        belirtilen saklama süresi içinde tamamen kaldırılır.
+      </p>
+
+      <h2>Hangi veriler silinir, ne kadar süre saklanır?</h2>
+      <p>
+        Talebiniz onaylandıktan sonra hesabınız ve ilişkili kişisel
+        verileriniz — kimlik bilgileriniz (ad, soyad), iletişim bilgileriniz
+        (e-posta, telefon) ve kullanım verileriniz (okunan makaleler,
+        beğeniler, kaydedilen içerikler) dâhil — <strong>30 gün</strong>
+        içinde kalıcı olarak silinir veya anonim hâle getirilir.
+      </p>
+      <p>
+        Yalnızca yasal yükümlülükler gereği saklanması zorunlu olan veriler
+        (örneğin mevzuatın öngördüğü ticari kayıtlar), ilgili mevzuatta
+        belirtilen süreler boyunca muhafaza edilir. Verilerin işlenmesine
+        ilişkin ayrıntılar için
+        <a href="/gizlilik-politikasi.html">Gizlilik Politikası</a>
+        sayfamıza bakabilirsiniz.
+      </p>
+
+      <hr />
+
+      <h2>Hesap silme talebi formu</h2>
+      <p>
+        Tüm veriler, güvenli bağlantı (HTTPS/TLS) üzerinden şifrelenerek
+        iletilir.
+      </p>
+
+      <form id="deletion-form">
+        <div class="field">
+          <label class="label" for="deletion-email">E-posta adresiniz</label>
+          <div class="control has-icons-left">
+            <input
+              class="input"
+              type="email"
+              id="deletion-email"
+              name="email"
+              placeholder="ornek@eposta.com"
+              autocomplete="email"
+              required
+            />
+            <span class="icon is-left">
+              <i class="fas fa-envelope"></i>
+            </span>
+          </div>
+        </div>
+
+        <div class="field">
+          <label class="label" for="deletion-reason">
+            Silme nedeni <span class="has-text-grey">(isteğe bağlı)</span>
+          </label>
+          <div class="control">
+            <textarea
+              class="textarea"
+              id="deletion-reason"
+              name="reason"
+              rows="3"
+              placeholder="Dilerseniz hesabınızı neden sildiğinizi paylaşabilirsiniz."
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="field">
+          <button class="button is-primary" type="submit">
+            Silme talebi gönder
+          </button>
+        </div>
+
+        <p id="deletion-message" class="help mt-3"></p>
+      </form>
+    </div>
+  </section>
+</main>

--- a/js/account-deletion-confirm.js
+++ b/js/account-deletion-confirm.js
@@ -1,0 +1,87 @@
+// /hesap-silme-onayi — confirm an account-deletion request.
+//
+// The email's confirm link carries `id` + `token` in the query string.
+// This page POSTs them to confirmAccountDeletionRequest (with an App Check
+// token) and shows the outcome in Turkish. On success the request flips
+// from awaiting_confirmation to pending and the 30-day window starts.
+import { getAppCheckToken } from "./firebase-app-check.js";
+
+const ENDPOINT =
+  "https://europe-west1-dipnotapp.cloudfunctions.net/confirmAccountDeletionRequest";
+
+const statusBox = document.getElementById("confirm-status");
+const spinner = document.getElementById("confirm-spinner");
+
+function show(html, type) {
+  spinner.classList.add("is-hidden");
+  statusBox.className = `notification is-${type}`;
+  statusBox.innerHTML = html;
+  statusBox.classList.remove("is-hidden");
+}
+
+const INVALID_LINK =
+  '<p class="title is-5">Bağlantı geçersiz</p>' +
+  "<p>Bu onay bağlantısı eksik veya hatalı. Lütfen e-postanızdaki " +
+  "bağlantıyı tam olarak kullanın ya da " +
+  '<a href="/hesap-silme.html">silme talebini yeniden oluşturun</a>.</p>';
+
+async function confirm() {
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get("id");
+  const token = params.get("token");
+
+  if (!id || !token) {
+    show(INVALID_LINK, "warning");
+    return;
+  }
+
+  try {
+    const appCheckToken = await getAppCheckToken();
+
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Firebase-AppCheck": appCheckToken,
+      },
+      body: JSON.stringify({ id, token }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      // Expired / already-used / invalid token → actionable error.
+      show(
+        '<p class="title is-5">Onaylanamadı</p>' +
+          "<p>" +
+          (data.error ||
+            "Bu bağlantı geçersiz veya süresi dolmuş olabilir.") +
+          " " +
+          'Dilerseniz <a href="/hesap-silme.html">silme talebini yeniden ' +
+          "oluşturabilirsiniz</a>.</p>",
+        "warning",
+      );
+      return;
+    }
+
+    show(
+      '<p class="title is-5">Talebiniz onaylandı</p>' +
+        "<p>" +
+        (data.message ||
+          "Hesap silme talebiniz onaylandı. Hesabınız 30 gün içinde kalıcı " +
+          "olarak silinecektir.") +
+        "</p>",
+      "success",
+    );
+  } catch (err) {
+    show(
+      '<p class="title is-5">Bir hata oluştu</p>' +
+        "<p>" +
+        (err.message || "Lütfen daha sonra tekrar deneyin.") +
+        "</p>",
+      "danger",
+    );
+  }
+}
+
+confirm();

--- a/js/account-deletion.js
+++ b/js/account-deletion.js
@@ -1,0 +1,61 @@
+// /hesap-silme — account-deletion request form.
+//
+// Posts the account email (+ optional reason) to the public
+// submitAccountDeletionRequest Cloud Function with an App Check token.
+// This does NOT delete anything yet: the backend emails the owner a
+// single-use confirm link (double opt-in). The success copy says so.
+import { getAppCheckToken } from "./firebase-app-check.js";
+
+const ENDPOINT =
+  "https://europe-west1-dipnotapp.cloudfunctions.net/submitAccountDeletionRequest";
+
+const form = document.getElementById("deletion-form");
+const emailInput = document.getElementById("deletion-email");
+const reasonInput = document.getElementById("deletion-reason");
+const message = document.getElementById("deletion-message");
+const button = form.querySelector("button[type=submit]");
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+
+  message.textContent = "";
+  message.className = "help mt-3";
+  button.classList.add("is-loading");
+  button.disabled = true;
+
+  try {
+    const token = await getAppCheckToken();
+
+    const payload = { email: emailInput.value };
+    const reason = reasonInput.value.trim();
+    if (reason) payload.reason = reason;
+
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Firebase-AppCheck": token,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.error || "Bir hata oluştu. Lütfen tekrar deneyin.");
+    }
+
+    message.textContent =
+      data.message ||
+      "Onay e-postası gönderildi. Hesabınızın silinmesi için e-postadaki bağlantıya tıklayın.";
+    message.classList.add("is-success");
+    form.reset();
+  } catch (err) {
+    message.textContent =
+      err.message || "Bir hata oluştu. Lütfen tekrar deneyin.";
+    message.classList.add("is-danger");
+  } finally {
+    button.classList.remove("is-loading");
+    button.disabled = false;
+  }
+});

--- a/js/firebase-app-check.js
+++ b/js/firebase-app-check.js
@@ -1,0 +1,56 @@
+// Firebase App Check bootstrap for the account-deletion endpoints.
+//
+// The account-deletion Cloud Functions (submitAccountDeletionRequest,
+// confirmAccountDeletionRequest) are plain HTTP onRequest handlers that
+// REQUIRE a valid App Check token in the `X-Firebase-AppCheck` header in
+// production — they reject requests without one. Because they are not
+// callable functions, the token must be attached manually to each fetch.
+//
+// This module is the single place landing initialises Firebase. It is an
+// ES module loaded with <script type="module"> (the rest of the site uses
+// plain IIFE scripts; only the deletion pages need this). Other module
+// scripts import getAppCheckToken() from here.
+//
+// All values below are PUBLIC client config — the web apiKey identifies the
+// Firebase project, it does not authorise anything. Safe to ship in source.
+//
+// Firebase JS SDK is pinned to 11.6.1 from Google's gstatic CDN. ES module
+// imports can't carry an SRI hash today, so this is the one CDN dependency
+// on the site without subresource integrity (gstatic is Google's own CDN).
+// Bump the version in BOTH import URLs together when updating.
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
+import {
+  initializeAppCheck,
+  ReCaptchaEnterpriseProvider,
+  getToken,
+} from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app-check.js";
+
+// "Dipnot Landing Page" web app (appId …e55962), registered with App Check
+// (reCAPTCHA Enterprise) 2026-06-01. Config pulled from the Firebase console.
+const firebaseConfig = {
+  apiKey: "AIzaSyCMde0m-88HChTa7dK4hV8i3_cZbvlTmpg",
+  authDomain: "dipnotapp.firebaseapp.com",
+  projectId: "dipnotapp",
+  storageBucket: "dipnotapp.firebasestorage.app",
+  messagingSenderId: "579105552455",
+  appId: "1:579105552455:web:6cf0dfcd33645135e55962",
+  measurementId: "G-YSQJLFK4HZ",
+};
+
+// Public reCAPTCHA Enterprise site key (provided by FirebaseFunctions).
+const RECAPTCHA_SITE_KEY = "6LcchwctAAAAAKXJ_ubcd0VpAzcsfYSC9A84-4te";
+
+const app = initializeApp(firebaseConfig);
+const appCheck = initializeAppCheck(app, {
+  provider: new ReCaptchaEnterpriseProvider(RECAPTCHA_SITE_KEY),
+  isTokenAutoRefreshEnabled: true,
+});
+
+// Returns a fresh App Check token to attach as `X-Firebase-AppCheck`.
+// `false` = don't force-refresh; the SDK serves a cached token until it
+// nears expiry. Throws if the token can't be obtained (e.g. reCAPTCHA
+// blocked) — callers surface that as a user-facing error.
+export async function getAppCheckToken() {
+  const { token } = await getToken(appCheck, false);
+  return token;
+}

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -38,7 +38,7 @@ og:
       <h1>Privacy Policy (KVKK)</h1>
       <p>
         <strong>Last updated:</strong>
-        <time datetime="2026-04-24">24 April 2026</time>
+        <time datetime="2026-06-02">2 June 2026</time>
       </p>
 
       <div class="notification is-warning">
@@ -177,6 +177,19 @@ og:
             in Europe (Belgium, europe-west1).</span
           >
         </li>
+        <li>
+          <strong>Brevo (Sendinblue SAS – European Union):</strong>
+          <br />
+          <span
+            >The single-use confirmation link sent to verify your
+            account-deletion request is delivered through Brevo's transactional
+            email service; only your email address is processed for this purpose.
+            Your data is hosted on Brevo's servers in the European Union (France
+            / Germany – OVH, and Google Cloud Belgium). Limited transfers to the
+            USA / India via sub-processors are protected by appropriate
+            safeguards (standard contractual clauses).</span
+          >
+        </li>
       </ul>
       <p>
         Where cross-border transfer is involved, transfers are made under KVKK
@@ -247,6 +260,11 @@ og:
         information sufficient to verify your identity. Your requests will be
         answered free of charge as soon as possible (within 30 days at the
         latest).
+      </p>
+      <p>
+        To delete your account and data without signing into the app, you can
+        also use the form on the
+        <a href="/hesap-silme.html">Account Deletion</a> page.
       </p>
 
       <h2>7. Advertising and Marketing Emails</h2>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,8 +14,14 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://dipnot.app/hesap-silme.html</loc>
+    <lastmod>2026-06-02</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
     <loc>https://dipnot.app/gizlilik-politikasi.html</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-06-02</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <xhtml:link rel="alternate" hreflang="tr" href="https://dipnot.app/gizlilik-politikasi.html"/>
@@ -23,7 +29,7 @@
   </url>
   <url>
     <loc>https://dipnot.app/privacy-policy.html</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-06-02</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <xhtml:link rel="alternate" hreflang="tr" href="https://dipnot.app/gizlilik-politikasi.html"/>


### PR DESCRIPTION
Closes #92. Implements the public account-deletion flow — the last surface of the cross-repo flow and the Google Play Data Safety blocker for the Android production submission (mobile #302). Built from the five `to-landing.md` inbox asks (mobile, functions ×2, core_docs ×2).

## What's in here

- **`hesap-silme.html`** — public, no-login page. Covers Google's three required elements (app + developer name = Dipnot; deletion steps; what's deleted vs. retained + the 30-day window), the in-app path (Ayarlar → "Hesabımı Sil" → "Evet, Sil"), an HTTPS note, and the request form (email + optional reason). **Double opt-in** success copy — submitting only triggers a confirmation email; nothing is deleted until the owner clicks the link.
- **`hesap-silme-onayi.html`** — confirm page. Reads `id` + `token` from the email link's query string and POSTs them to `confirmAccountDeletionRequest`. `noindex` (transactional landing for email links only).
- **First Firebase wiring on landing.** `js/firebase-app-check.js` inits Firebase + App Check (reCAPTCHA Enterprise) and exposes a token getter. Both endpoints require an `X-Firebase-AppCheck` header (they're plain `onRequest`, so the token is attached manually). Loaded as ES modules via a new conditional `pageModule` hook in `base.njk`; the rest of the site stays on plain IIFE scripts.
- **Privacy policy** (TR authoritative + EN mirror) — mirrored the ratified **Brevo** processor snippet and bumped both dates to 2026-06-02 (core_docs #119).
- Linked `/hesap-silme` from the footer and both privacy policies; added it to the sitemap; bumped `jsVersion`.

## Endpoints (region `europe-west1`)
`submitAccountDeletionRequest` (POST `{email, reason?}`) and `confirmAccountDeletionRequest` (POST `{id, token}`) — pattern URLs; functions will confirm exact URLs in the deploy ack.

## Config note
Uses the public **"Dipnot Landing Page"** web app config (appId `…e55962`) + public reCAPTCHA Enterprise site key. All public client values — the `apiKey` identifies, it doesn't authorise.

## Checks
- `html-validate` (hard gate): **pass**.
- `pa11y`: 5 pre-existing footer-contrast errors (every page, unchanged); the deletion pages add 4 errors that are **all** from App Check's runtime-injected reCAPTCHA DOM (hidden textarea + iframe) — third-party, unfixable. My own form fields are properly labelled. pa11y is `continue-on-error`.

## Known divergence
ES module imports can't carry SRI, so the Firebase SDK (pinned 11.6.1 on gstatic) is the one CDN dep without a subresource-integrity hash. Flagged in the module's header comment.

## Follow-ups (post-merge + deploy)
- Ack live URLs to `to-mobile.md` and `to-functions.md`; ack the policy mirror to `to-core-docs.md` (closes the #119 publish item).
- Delete the five handled `to-landing.md` inbox messages.
- core_docs CHANGELOG entry for the landing-side Brevo sync (staged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)