### PR TITLE
Update Android download buttons to Play Store link

### DIFF
--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -114,7 +114,7 @@
           <p class="menu-label">Uygulamayı indir</p>
 
           <div class="buttons are-small">
-            <a href="https://expo.dev/accounts/vac-studio/projects/dipnotAPP/builds/7da6b322-9983-4747-9d73-70072b4c7ac9" target="_blank" rel="noopener noreferrer" class="button is-light is-inverted is-outlined is-rounded">
+            <a href="https://play.google.com/store/apps/details?id=com.vacstudio.dipnot" target="_blank" rel="noopener noreferrer" class="button is-light is-inverted is-outlined is-rounded">
               <img src="/img/svg/google-play.svg" alt="Google Play">
               <span class="ml-2">Google Play</span>
             </a>

--- a/_includes/partials/nav.njk
+++ b/_includes/partials/nav.njk
@@ -57,7 +57,7 @@
         </div>
         <div class="navbar-item">
           <div class="buttons are-small">
-            <a href="https://expo.dev/accounts/vac-studio/projects/dipnotAPP/builds/7da6b322-9983-4747-9d73-70072b4c7ac9" target="_blank" class="button is-light is-inverted is-outlined is-rounded">
+            <a href="https://play.google.com/store/apps/details?id=com.vacstudio.dipnot" target="_blank" rel="noopener noreferrer" class="button is-light is-inverted is-outlined is-rounded">
               <img src="/img/svg/google-play.svg" alt="Google Play">
               <span class="ml-2">Google Play</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ hasContactForm: true
         <div
           class="buttons are-large mt-6 is-flex is-justify-content-center mb-6"
         >
-          <a href="https://expo.dev/accounts/vac-studio/projects/dipnotAPP/builds/7da6b322-9983-4747-9d73-70072b4c7ac9" target="_blank" class="button is-light is-outlined is-rounded">
+          <a href="https://play.google.com/store/apps/details?id=com.vacstudio.dipnot" target="_blank" rel="noopener noreferrer" class="button is-light is-outlined is-rounded">
             <img src="/img/svg/google-play.svg" alt="Google Play" />
             <span class="ml-2">Google Play</span>
           </a>
@@ -343,7 +343,7 @@ hasContactForm: true
         alan içerikler...
       </p>
       <div class="buttons are-large mt-6 is-flex is-justify-content-center">
-        <a href="https://expo.dev/accounts/vac-studio/projects/dipnotAPP/builds/7da6b322-9983-4747-9d73-70072b4c7ac9" target="_blank" class="button is-light is-outlined is-rounded">
+        <a href="https://play.google.com/store/apps/details?id=com.vacstudio.dipnot" target="_blank" rel="noopener noreferrer" class="button is-light is-outlined is-rounded">
           <img src="/img/svg/google-play.svg" alt="Google Play" />
           <span class="ml-2">Google Play</span>
         </a>


### PR DESCRIPTION
Point all four "Google Play" buttons at the canonical Play Store listing
(`https://play.google.com/store/apps/details?id=com.vacstudio.dipnot`)
instead of the old Expo build URL.

Buttons updated:
- `_includes/partials/nav.njk` — top nav
- `_includes/partials/footer.njk` — footer
- `index.html` — hero CTA + download CTA

Also added `rel="noopener noreferrer"` to the Google Play anchors that
were missing it (the App Store anchors already had it), per the
security baseline in CLAUDE.md.

The Play Store URL is keyed by the permanent package id
(`com.vacstudio.dipnot`), so it stays valid once the app is promoted
from testing to production — no future swap needed.

Refs #5 (will close manually after merge — PR targets `dev`, not the
default branch, so no auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)