### PR TITLE
Add iletisim.html contact page

### DIFF
--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -156,7 +156,7 @@
 
     <div class="columns mt-6">
       <div class="column has-text-centered">
-        Copyright &copy; 2025&ndash;2026 <span class="mx-4">|</span> <a href="/gizlilik-politikasi.html">Gizlilik politikası</a> <span class="mx-4">|</span> <a href="/kullanim-kosullari.html">Kullanım koşulları</a> <span class="mx-4">|</span> <a href="/hesap-silme.html">Hesap silme</a>
+        Copyright &copy; 2025&ndash;2026 <span class="mx-4">|</span> <a href="/gizlilik-politikasi.html">Gizlilik politikası</a> <span class="mx-4">|</span> <a href="/kullanim-kosullari.html">Kullanım koşulları</a> <span class="mx-4">|</span> <a href="/hesap-silme.html">Hesap silme</a> <span class="mx-4">|</span> <a href="/iletisim.html">İletişim</a>
         <br>
         Website <a href="https://vacstudio.com/" target="_blank" rel="noopener noreferrer">V.A.C. Studio</a> tarafından geliştirilmiştir.
       </div>

--- a/iletisim.html
+++ b/iletisim.html
@@ -1,0 +1,82 @@
+---
+layout: base.njk
+lang: tr
+title: "İletişim | Dipnot App"
+description: "Dipnot ile iletişim. Yayıncı kimliği, adres ve iletişim e-posta adresleri (genel iletişim ve teknik destek)."
+keywords: "dipnot, iletişim, iletisim, destek, yayıncı, contact"
+hreflang:
+  - lang: tr
+    href: "https://dipnot.app/iletisim.html"
+og:
+  locale: tr_TR
+  url: "https://dipnot.app/iletisim.html"
+  description: "Dipnot ile iletişim: yayıncı kimliği, adres ve iletişim e-posta adresleri."
+---
+
+<!-- HERO BANNER -->
+<section class="hero has-background-hero">
+  <div class="hero-body">
+    <div class="columns">
+      <div class="column">
+        <p class="title is-size-1 has-text-white mb-5">
+          İletişim
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- MAIN PAGE -->
+<main class="container py-6">
+  <section class="section">
+    <div class="content">
+      <h1>Dipnot ile İletişim</h1>
+      <p>
+        <strong>Dipnot</strong>, dalış dünyasını derinlemesine ele alan
+        içerikler sunan bir mobil uygulamadır. Uygulama
+        <strong>V.A.C. Studio</strong> tarafından geliştirilmektedir.
+        Aşağıdaki bilgilerden bize ulaşabilirsiniz.
+      </p>
+
+      <h2>Yayıncı bilgileri</h2>
+      <p>
+        <strong>Uygulama:</strong> Dipnot<br />
+        <strong>Geliştirici:</strong> V.A.C. Studio
+      </p>
+      <address>
+        1. Kısım Mah. Vali Recep Yazıcıoğlu Cad. Doğa Parkı Evleri BC Blok
+        No:15/13 Bahçeşehir, İstanbul, Türkiye.
+      </address>
+
+      <h2>E-posta</h2>
+      <p>
+        <span class="icon mr-2">
+          <i class="fa-solid fa-envelope"></i>
+        </span>
+        <strong>Genel iletişim:</strong>
+        <a href="mailto:info@dipnot.app">info@dipnot.app</a>
+      </p>
+      <p>
+        <span class="icon mr-2">
+          <i class="fa-solid fa-life-ring"></i>
+        </span>
+        <strong>Teknik destek:</strong>
+        <a href="mailto:help@dipnot.app">help@dipnot.app</a>
+      </p>
+
+      <h2>İletişim formu</h2>
+      <p>
+        Bize mesaj göndermek için ana sayfamızdaki
+        <a href="/#contact">iletişim formunu</a> da
+        kullanabilirsiniz. Tüm veriler güvenli bağlantı (HTTPS/TLS)
+        üzerinden şifrelenerek iletilir.
+      </p>
+
+      <p>
+        Kişisel verilerinizin işlenmesine ilişkin ayrıntılar için
+        <a href="/gizlilik-politikasi.html">Gizlilik Politikası</a>
+        sayfamıza bakabilirsiniz.
+      </p>
+    </div>
+  </section>
+</main>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,6 +20,12 @@
     <priority>0.3</priority>
   </url>
   <url>
+    <loc>https://dipnot.app/iletisim.html</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
     <loc>https://dipnot.app/gizlilik-politikasi.html</loc>
     <lastmod>2026-06-02</lastmod>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
Adds a dedicated Turkish contact page at `/iletisim.html`, requested by
the mobile agent (core_docs inbox) for the Play Console **News &
Magazine entity declaration**, which needs a canonical URL exposing the
publisher's contact info.

### What's included
- **`iletisim.html`** — publisher identity (Dipnot / V.A.C. Studio),
  registered address, contact emails (`info@dipnot.app` general,
  `help@dipnot.app` technical), and a link to the homepage contact
  form. Follows the `hesap-silme.html` legal-page pattern.
- **Footer link** — added to the copyright legal line next to Gizlilik /
  Kullanım / Hesap silme.
- **`sitemap.xml`** — new entry.

### Dead `/iletisim` route
`www.dipnot.app/iletisim` → `dipnot.app/iletisim` previously 404'd.
GitHub Pages serves `iletisim.html` for the extensionless `/iletisim`
path, so the page's existence resolves the dead route. Will verify
post-deploy.

### Checks
- `npm run build` — clean (10 files)
- `html-validate _site/iletisim.html` — passes

Once merged + deployed, I'll ack the mobile agent in the core_docs
inbox with the live URL (they want to switch the Play Console
declaration to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)