### PR TITLE
Disclose newsletter + reCAPTCHA Enterprise in privacy policy

### DIFF
--- a/gizlilik-politikasi.html
+++ b/gizlilik-politikasi.html
@@ -39,7 +39,7 @@ og:
       <h1>Gizlilik Politikası ve Aydınlatma Metni (KVKK)</h1>
       <p>
         <strong>Son Güncelleme:</strong>
-        <time datetime="2026-06-02">2 Haziran 2026</time>
+        <time datetime="2026-06-03">3 Haziran 2026</time>
       </p>
 
       <h2>1. Veri Sorumlusu ve Temsilcisi</h2>
@@ -157,6 +157,22 @@ og:
         </li>
         <li>
           <strong
+            >Firebase Cloud Functions — Bülten Aboneliği (Google LLC,
+            europe-west1 – Belçika, AB):</strong
+          >
+          <br />
+          <span
+            >dipnot.app web sitesinin alt bilgisindeki bülten kayıt formu
+            aracılığıyla verdiğiniz e-posta adresiniz, bülten listesine eklenmek
+            üzere Firebase Cloud Functions üzerinden işlenir ve Firestore'da
+            (<code>newsletter_subscribers</code> koleksiyonu) saklanır. Bu işlem
+            açık rızanıza dayanır; dilediğiniz zaman abonelikten çıkabilirsiniz.
+            Verileriniz Avrupa'daki sunucularda (Belçika, europe-west1)
+            işlenmektedir.</span
+          >
+        </li>
+        <li>
+          <strong
             >Firebase Cloud Functions — İletişim Formu (Google LLC, europe-west1
             – Belçika, AB):</strong
           >
@@ -183,6 +199,21 @@ og:
             Almanya – OVH ve Google Cloud Belçika) barındırılır. Sınırlı sayıda
             alt-işleyici aracılığıyla ABD / Hindistan'a yapılabilecek aktarımlar
             uygun güvencelerle (standart sözleşme hükümleri) korunur.</span
+          >
+        </li>
+        <li>
+          <strong>Google reCAPTCHA Enterprise (Google LLC – ABD):</strong>
+          <br />
+          <span
+            >dipnot.app üzerindeki form gönderimlerini (örneğin hesap silme
+            talebi) otomatik bot trafiğine ve kötüye kullanıma karşı korumak
+            amacıyla, Firebase App Check ile birlikte Google reCAPTCHA
+            Enterprise kullanılır. Bu kapsamda IP adresiniz ve site üzerindeki
+            etkileşim sinyalleriniz, bir güven (risk) puanı üretmek üzere Google
+            tarafından işlenir. Bu işleme, kötüye kullanımın önlenmesine yönelik
+            meşru menfaate dayanır. Google'ın ABD'deki sunucularına yapılan
+            aktarımlar KVKK md. 9 kapsamında gerekli güvencelerle
+            gerçekleştirilir.</span
           >
         </li>
       </ul>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -38,7 +38,7 @@ og:
       <h1>Privacy Policy (KVKK)</h1>
       <p>
         <strong>Last updated:</strong>
-        <time datetime="2026-06-02">2 June 2026</time>
+        <time datetime="2026-06-03">3 June 2026</time>
       </p>
 
       <div class="notification is-warning">
@@ -163,6 +163,21 @@ og:
         </li>
         <li>
           <strong
+            >Firebase Cloud Functions — Newsletter signup (Google LLC,
+            europe-west1 – Belgium, EU):</strong
+          >
+          <br />
+          <span
+            >The email address you provide through the newsletter signup form in
+            the dipnot.app footer is processed by Firebase Cloud Functions and
+            stored in Firestore (<code>newsletter_subscribers</code> collection)
+            to be added to the newsletter list. This processing is based on your
+            explicit consent; you may unsubscribe at any time. Your data is
+            processed on servers in Europe (Belgium, europe-west1).</span
+          >
+        </li>
+        <li>
+          <strong
             >Firebase Cloud Functions — Contact form (Google LLC, europe-west1 –
             Belgium, EU):</strong
           >
@@ -188,6 +203,20 @@ og:
             / Germany – OVH, and Google Cloud Belgium). Limited transfers to the
             USA / India via sub-processors are protected by appropriate
             safeguards (standard contractual clauses).</span
+          >
+        </li>
+        <li>
+          <strong>Google reCAPTCHA Enterprise (Google LLC – USA):</strong>
+          <br />
+          <span
+            >To protect form submissions on dipnot.app (for example,
+            account-deletion requests) against automated bot traffic and abuse,
+            Google reCAPTCHA Enterprise is used together with Firebase App Check.
+            In this context your IP address and interaction signals on the site
+            are processed by Google to produce a trust (risk) score. This
+            processing is based on our legitimate interest in preventing abuse.
+            Transfers to Google's servers in the USA are carried out with the
+            necessary safeguards under KVKK article 9.</span
           >
         </li>
       </ul>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -27,7 +27,7 @@
   </url>
   <url>
     <loc>https://dipnot.app/gizlilik-politikasi.html</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <xhtml:link rel="alternate" hreflang="tr" href="https://dipnot.app/gizlilik-politikasi.html"/>
@@ -35,7 +35,7 @@
   </url>
   <url>
     <loc>https://dipnot.app/privacy-policy.html</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <xhtml:link rel="alternate" hreflang="tr" href="https://dipnot.app/gizlilik-politikasi.html"/>


### PR DESCRIPTION
Mirrors two new processor entries from the `core_docs`
`data-processors.md` registry into both KVKK policy files
(`gizlilik-politikasi.html` authoritative TR + `privacy-policy.html` EN
mirror), per the privacy-policy sync protocol.

### 1. Newsletter signup — resolves #71
The footer newsletter form (`subscribeNewsletter`) processes email
addresses but had **no** disclosure. Decision (Nev, 2026-06-03): **own
entry**, by analogy with the contact-form precedent — distinct legal
basis (explicit consent), data category (email only), and opt-out
lifecycle. **Closes #71.**

### 2. Google reCAPTCHA Enterprise (Firebase App Check) — relates to #67
The account-deletion flow quietly introduced reCAPTCHA Enterprise via
App Check ([`js/firebase-app-check.js`](js/firebase-app-check.js)),
which sends IP + interaction signals to Google for a risk score — a
disclosable flow that wasn't in the registry or policy. Added an entry.
Region/legal basis (USA / KVKK art. 9 / legitimate interest) is a
**first cut**; an inbox ask to `FirebaseFunctions` asks them to confirm
the authoritative region + sub-processors (the site key originates in
that project). I'll re-mirror if it differs.

### Also
- Policy dates bumped to 2026-06-03 (TR + EN).
- `sitemap.xml` lastmod bumped for both policy pages.

### Registry side (already pushed to core_docs `main`, commit `62fc497`)
- Newsletter entry status → own entry + snippets.
- New reCAPTCHA Enterprise section + summary row.
- CHANGELOG entry; open item + functions inbox ask for the region
  confirmation.

### Checks
- `npm run build` — clean
- `html-validate` on both policy pages — passes

Note: PR targets `dev`, so #71 won't auto-close on merge — I'll close
it manually after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)