### PR TITLE
Add, yarışma koşulları page for the 2026 dive centre competition

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -42,6 +42,12 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://dipnot.app/privacy-policy.html"/>
   </url>
   <url>
+    <loc>https://dipnot.app/yarisma-kosullari.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
     <loc>https://dipnot.app/kullanim-kosullari.html</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>yearly</changefreq>

--- a/yarisma-kosullari.html
+++ b/yarisma-kosullari.html
@@ -1,0 +1,264 @@
+---
+layout: base.njk
+lang: tr
+title: "Yarışma Koşulları | Dipnot App"
+description: "Dipnot 2026 Yılın Dalış Merkezi yarışmasının koşulları — katılım, oylama kuralları, takvim, ödül ve kazananın ilanı."
+keywords: "dipnot, yarışma koşulları, dalış merkezi yarışması, oylama"
+og:
+  locale: tr_TR
+  url: "https://dipnot.app/yarisma-kosullari.html"
+---
+
+<!-- HERO BANNER -->
+<section class="hero has-background-hero">
+  <div class="hero-body">
+    <div class="columns">
+      <div class="column">
+        <p class="title is-size-1 has-text-white mb-5">
+          Yarışma <span class="has-text-primary">Koşulları</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- MAIN PAGE -->
+<main class="container py-6">
+  <!-- CONTENT -->
+  <section class="section">
+    <div class="content">
+      <h1>Yarışma Koşulları</h1>
+      <p>
+        <strong>Son Güncelleme:</strong>
+        <time datetime="2026-07-25">25 Temmuz 2026</time>
+      </p>
+
+      <h2>1. Yarışmanın Konusu ve Düzenleyen</h2>
+      <p>
+        Dipnot, kullanıcılarının oylarıyla <strong>2026 Yılın Dalış
+        Merkezi</strong>'ni belirlemek üzere bir yarışma düzenlemektedir
+        ("Yarışma"). Yarışmayı düzenleyen Dipnot Uygulama Ekibi'dir.
+      </p>
+      <p>
+        Kazanan, <strong>en çok oyu alan dalış merkezidir</strong>. Kazananın
+        belirlenmesinde kura, çekiliş veya herhangi bir şans unsuru
+        kullanılmaz; sonuç yalnızca kullanıcı oylarının sayısına göre
+        belirlenir.
+      </p>
+
+      <h2>2. Katılım Koşulları</h2>
+      <ul>
+        <li>
+          Dipnot mobil uygulamasına kayıtlı olan her kullanıcı oy kullanabilir.
+        </li>
+        <li>
+          Katılım <strong>tamamen ücretsizdir</strong>. Oy kullanmak için tek
+          gereklilik uygulamaya kayıt olmak ve hesabınıza giriş yapmaktır.
+          Herhangi bir ücret, satın alma veya abonelik şartı yoktur.
+        </li>
+        <li>
+          Oy kullanmak için uygulamanın güncel sürümünün cihazınızda yüklü
+          olması gerekir.
+        </li>
+      </ul>
+
+      <h2>3. Oylama Kuralları</h2>
+      <ul>
+        <li>
+          Bir kullanıcı <strong>birden fazla dalış merkezine</strong> oy
+          verebilir.
+        </li>
+        <li>
+          Bir kullanıcı <strong>aynı dalış merkezine yalnızca bir kez</strong>
+          oy verebilir. Aynı merkeze birden fazla oy kullanılamaz.
+        </li>
+        <li>
+          Oylar geri alınabilir. Yarışma süresi boyunca dilediğiniz zaman oy
+          verebilir, verdiğiniz oyu geri çekebilir veya oyunuzu başka bir
+          merkeze aktarabilirsiniz.
+        </li>
+        <li>
+          Oylama süresi sona erdiğinde geçerli olan oy dağılımı esas alınır.
+        </li>
+      </ul>
+
+      <h2>4. Yarışma Takvimi</h2>
+      <ul>
+        <li>
+          <strong>Oylamanın başlangıcı:</strong>
+          <time datetime="2026-09-01T00:00+03:00">1 Eylül 2026, saat 00:00</time>
+          (TSİ)
+        </li>
+        <li>
+          <strong>Oylamanın bitişi:</strong>
+          <time datetime="2026-11-30T23:59+03:00"
+            >30 Kasım 2026, saat 23:59</time
+          >
+          (TSİ) &mdash; oylama 1 Aralık 2026 tarihine girildiği anda kapanır.
+        </li>
+        <li>
+          <strong>Kazananın ilanı:</strong>
+          <time datetime="2026-12-15">15 Aralık 2026</time>
+        </li>
+      </ul>
+
+      <h2>5. Aday Dalış Merkezleri Listesi</h2>
+      <ul>
+        <li>
+          Yarışmanın aday listesi, Türkiye Sualtı Sporları Federasyonu (TSSF)
+          tarafından yayımlanan faaliyetteki dalış merkezleri listesinden
+          alınmıştır.
+        </li>
+        <li>
+          Liste, oylamanın başladığı
+          <time datetime="2026-09-01">1 Eylül 2026</time> tarihindeki hâliyle
+          sabitlenir. Bu tarihten sonra TSSF listesine eklenen dalış merkezleri
+          Yarışma'ya dâhil edilmez.
+        </li>
+        <li>
+          TSSF listesinde yer almayan hiçbir dalış merkezi Yarışma'ya
+          eklenmez.
+        </li>
+        <li>
+          Listede yer almak istemeyen dalış merkezleri,
+          <a href="mailto:info@dipnot.app">info@dipnot.app</a> adresine
+          yazarak <strong>Yarışma süresi boyunca istedikleri zaman</strong>
+          listeden çıkarılmayı talep edebilir. Listeden çıkarılan bir merkez
+          Yarışma'dan ayrılmış sayılır ve o merkeze o ana kadar verilmiş olan
+          oylar geçersiz kabul edilir.
+        </li>
+      </ul>
+
+      <h2>6. Kazananın Belirlenmesi</h2>
+      <ul>
+        <li>
+          Oylamanın bitiş anı itibarıyla en çok geçerli oyu alan tek dalış
+          merkezi Yarışma'nın kazananıdır.
+        </li>
+        <li>
+          Geçersiz sayılan oylar (bkz. Madde 9) toplam oy sayısından düşülür.
+        </li>
+        <li>
+          Oy sayılarının eşit olması hâlinde kazanan Dipnot tarafından
+          belirlenir.
+        </li>
+      </ul>
+
+      <h2>7. Ödül</h2>
+      <p>Yarışma'yı kazanan dalış merkezine aşağıdaki ödüller verilir:</p>
+      <ul>
+        <li>Dipnot uygulaması içinde görüntülenen bir başarı rozeti</li>
+        <li>2026 Yılın Dalış Merkezi ödül belgesi</li>
+        <li>
+          <a href="https://diver.com.tr" target="_blank" rel="noopener noreferrer"
+            >diver.com.tr</a
+          >
+          üzerinde geçerli 10.000 TL değerinde alışveriş indirimi
+        </li>
+      </ul>
+      <p>
+        Ödüller kazanan dalış merkezine özeldir; üçüncü kişilere devredilemez ve
+        nakde çevrilemez. Teslim edilen ödül, burada ilan edilen ödülle aynıdır.
+      </p>
+
+      <h2>8. Kazananın İlanı ve Ödülün Teslimi</h2>
+      <ul>
+        <li>
+          Kazanan <time datetime="2026-12-15">15 Aralık 2026</time> tarihinde
+          Dipnot'un
+          <a
+            href="https://www.instagram.com/dipnot.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Instagram</a
+          >
+          ve
+          <a
+            href="https://www.facebook.com/profile.php?id=61568027754102"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Facebook</a
+          >
+          hesaplarından ve Dipnot uygulaması içinde yayımlanacak bir makale ile
+          duyurulur.
+        </li>
+        <li>
+          İlanın ardından kazanan dalış merkezi ile Dipnot tarafından iletişime
+          geçilir.
+        </li>
+        <li>
+          Ödül, kazanan dalış merkezine <strong>elden teslim edilir veya
+          kargo ile gönderilir</strong>. Teslim şekli kazanan merkez ile
+          birlikte kararlaştırılır; kargo bedeli Dipnot tarafından karşılanır.
+        </li>
+      </ul>
+
+      <h2>9. Kötüye Kullanım</h2>
+      <p>
+        Yarışma'nın adil şekilde sonuçlanmasını sağlamak amacıyla Dipnot,
+        aşağıdaki hakları saklı tutar:
+      </p>
+      <ul>
+        <li>
+          Sahte, otomatik veya çoklu hesaplar üzerinden kullanıldığı tespit
+          edilen oyları geçersiz saymak.
+        </li>
+        <li>
+          Bu tür oyların kullanılmasını organize ettiği tespit edilen dalış
+          merkezini Yarışma'dan diskalifiye etmek.
+        </li>
+        <li>
+          Kullanım Koşulları'nı ihlal eden hesapların oylarını iptal etmek.
+        </li>
+      </ul>
+      <p>
+        Bu kapsamdaki değerlendirmeler Dipnot tarafından yapılır ve sonuç
+        kesindir.
+      </p>
+
+      <h2>10. Kişisel Verilerin Korunması</h2>
+      <p>
+        Yarışma kapsamında işlenen kişisel verileriniz,
+        <a href="/gizlilik-politikasi.html">Gizlilik Politikası</a>'nda
+        belirtilen esaslara tabidir. Oy sonuçları yalnızca toplam sayı olarak
+        değerlendirilir; hangi kullanıcının hangi merkeze oy verdiği kamuya
+        açıklanmaz.
+      </p>
+
+      <h2>11. Koşullarda Değişiklik</h2>
+      <p>
+        Dipnot, Yarışma'nın takvimini, ödülünü veya işbu koşulları değiştirme
+        hakkını saklı tutar. Değişiklikler bu sayfada yayımlanır ve Madde 8'de
+        belirtilen kanallardan duyurulur. Yarışma başladıktan sonra yapılacak
+        değişiklikler, katılımcıların aleyhine sonuç doğurmayacak şekilde
+        uygulanır.
+      </p>
+
+      <h2>12. Uygulanacak Hukuk ve Yetki</h2>
+      <p>
+        İşbu koşullar Türkiye Cumhuriyeti kanunlarına tabidir. Yarışma'dan doğan
+        veya Yarışma ile ilgili her türlü uyuşmazlıkta İstanbul (Çağlayan)
+        Mahkemeleri ve İcra Daireleri yetkilidir.
+      </p>
+
+      <h2>13. İletişim</h2>
+      <p>
+        Aday listesinden çıkarılma talepleri ve Yarışma ile ilgili dalış merkezi
+        başvuruları için:
+      </p>
+      <p>
+        <span class="icon mr-2">
+          <i class="fa-solid fa-envelope"></i>
+        </span>
+        <a href="mailto:info@dipnot.app">info@dipnot.app</a>
+      </p>
+      <p>Yarışma hakkındaki diğer tüm soru ve şikayetleriniz için:</p>
+      <p>
+        <span class="icon mr-2">
+          <i class="fa-solid fa-envelope"></i>
+        </span>
+        <a href="mailto:help@dipnot.app">help@dipnot.app</a>
+      </p>
+    </div>
+  </section>
+</main>


### PR DESCRIPTION
Closes #119.

Adds `yarisma-kosullari.html` at the URL mobile has already hardcoded into the 1.6.0 competition screen:

**https://dipnot.app/yarisma-kosullari.html**

This is a launch blocker for DipnotAPP epic [#477](https://github.com/Dipnot-App/DipnotAPP/issues/477) — Turkish advertising rules require the terms to be published before the campaign opens.

## What's in the page

Follows the `kullanim-kosullari.html` structure and frontmatter convention (no `hreflang` — Turkish only, no EN mirror).

| Section | Content |
| --- | --- |
| 1 | Winner is the centre with the most votes; explicitly not a draw |
| 2 | Any registered Dipnot user; free, login is the only cost |
| 3 | Multiple centres allowed, one vote per centre, unvote/recast freely |
| 4 | 1 Eylül 2026 00:00 → 30 Kasım 2026 23:59 (TSİ); announced 15 Aralık 2026 |
| 5 | TSSF list, frozen at the 1 Eylül snapshot; opt-out via info@dipnot.app any time |
| 6 | Most valid votes wins; ties decided by Dipnot |
| 7 | Badge + award certificate + 10.000 TL diver.com.tr discount |
| 8 | Announced on Instagram, Facebook and an in-app article; prize in person or by cargo |
| 9 | Fake/multi-account votes voided; organising centre disqualified |
| 10 | Points at the privacy policy; only aggregate counts made public |
| 11 | Dates and prize may change, announced on the same channels |

Also adds the page to [sitemap.xml](sitemap.xml). Not added to the footer — it is a seasonal page that expires after 15 Aralık 2026, and mobile links to it directly.

## Judgement calls, flagged for review

- **Tie-break** is undecided, so the page says the winner is determined by Dipnot in a tie, rather than leaving the field blank.
- **Closing time** is published as `30 Kasım 2026 23:59 (TSİ)`, which is the same instant as "closes as 1 Aralık begins" but unambiguous to a reader.
- **Removed centres**: their existing votes are stated as void. This was not specified in the ask.
- **Contact split**: `info@dipnot.app` for list-removal requests as specified, `help@dipnot.app` for everything else to match the other legal pages.

## Checks

- `check:html` — pass
- `pa11y` — 5 errors, **identical to the `kullanim-kosullari.html` baseline**; all originate in the shared footer (4× `.menu-label` contrast at 4.41:1, 1× unlabelled newsletter email input). This page adds none.
- Links — `diver.com.tr`, Instagram and Facebook all 200; internal `/gizlilik-politikasi.html` builds.

## Follow-ups, not in this PR

- Vote data is new personal-data processing and is not yet reflected in the KVKK privacy policy.
- The pre-existing footer a11y errors deserve their own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)