### PR TITLE
Mark, tie-break rule as TBD pending decision

### DIFF
--- a/yarisma-kosullari.html
+++ b/yarisma-kosullari.html
@@ -138,6 +138,12 @@ og:
         <li>
           Geçersiz sayılan oylar (bkz. Madde 9) toplam oy sayısından düşülür.
         </li>
+        <!--
+          TBD: the tie-break mechanism itself is undecided. This wording keeps
+          the decision with Dipnot rather than publishing a blank field, and is
+          legally sufficient as-is. Decide before voting opens on 2026-09-01.
+          Tracked: https://github.com/Dipnot-App/www.dipnot.app/issues/121
+        -->
         <li>
           Oy sayılarının eşit olması hâlinde kazanan Dipnot tarafından
           belirlenir.


### PR DESCRIPTION
Refs #121.

Follow-up to #120 — this six-line comment was pushed while #120 was being merged, so it missed the merge by a few seconds. Content-only, no rendered output change.

Adds an inline `TBD` marker in [yarisma-kosullari.html](yarisma-kosullari.html) Madde 6, next to the tie-break clause:

```html
<!--
  TBD: the tie-break mechanism itself is undecided. This wording keeps
  the decision with Dipnot rather than publishing a blank field, and is
  legally sufficient as-is. Decide before voting opens on 2026-09-01.
  Tracked: https://github.com/Dipnot-App/www.dipnot.app/issues/121
-->
```

The published Turkish wording is unchanged — a reader still sees "eşitlik halinde kazanan Dipnot tarafından belirlenir". Nev asked for the open decision to be visible in the source rather than silently settled, and per CLAUDE.md an inline TODO needs a tracking issue, which is #121.

`check:html` passes; the comment does not alter rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)