### PR TITLE
Rename, competition to 2026 Yılın En Sevilen Dalış Merkezi

### DIFF
--- a/yarisma-kosullari.html
+++ b/yarisma-kosullari.html
@@ -1,8 +1,8 @@
 ---
 layout: base.njk
 lang: tr
-title: "Yarışma Koşulları | Dipnot App"
-description: "Dipnot 2026 Yılın Dalış Merkezi yarışmasının koşulları — katılım, oylama kuralları, takvim, ödül ve kazananın ilanı."
+title: "2026 Yarışma Koşulları | Dipnot App"
+description: "Dipnot 2026 Yılın En Sevilen Dalış Merkezi yarışmasının koşulları — katılım, oylama kuralları, takvim, ödül ve kazananın ilanı."
 keywords: "dipnot, yarışma koşulları, dalış merkezi yarışması, oylama"
 og:
   locale: tr_TR
@@ -27,7 +27,7 @@ og:
   <!-- CONTENT -->
   <section class="section">
     <div class="content">
-      <h1>Yarışma Koşulları</h1>
+      <h1>2026 Yarışma Koşulları</h1>
       <p>
         <strong>Son Güncelleme:</strong>
         <time datetime="2026-07-25">25 Temmuz 2026</time>
@@ -35,7 +35,7 @@ og:
 
       <h2>1. Yarışmanın Konusu ve Düzenleyen</h2>
       <p>
-        Dipnot, kullanıcılarının oylarıyla <strong>2026 Yılın Dalış
+        Dipnot, kullanıcılarının oylarıyla <strong>2026 Yılın En Sevilen Dalış
         Merkezi</strong>'ni belirlemek üzere bir yarışma düzenlemektedir
         ("Yarışma"). Yarışmayı düzenleyen Dipnot Uygulama Ekibi'dir.
       </p>
@@ -121,7 +121,7 @@ og:
         </li>
         <li>
           Listede yer almak istemeyen dalış merkezleri,
-          <a href="mailto:info@dipnot.app">info@dipnot.app</a> adresine
+          <a href="mailto:help@dipnot.app">help@dipnot.app</a> adresine
           yazarak <strong>Yarışma süresi boyunca istedikleri zaman</strong>
           listeden çıkarılmayı talep edebilir. Listeden çıkarılan bir merkez
           Yarışma'dan ayrılmış sayılır ve o merkeze o ana kadar verilmiş olan
@@ -154,7 +154,7 @@ og:
       <p>Yarışma'yı kazanan dalış merkezine aşağıdaki ödüller verilir:</p>
       <ul>
         <li>Dipnot uygulaması içinde görüntülenen bir başarı rozeti</li>
-        <li>2026 Yılın Dalış Merkezi ödül belgesi</li>
+        <li>2026 Yılın En Sevilen Dalış Merkezi ödül belgesi</li>
         <li>
           <a href="https://diver.com.tr" target="_blank" rel="noopener noreferrer"
             >diver.com.tr</a
@@ -249,16 +249,10 @@ og:
 
       <h2>13. İletişim</h2>
       <p>
-        Aday listesinden çıkarılma talepleri ve Yarışma ile ilgili dalış merkezi
-        başvuruları için:
+        Aday listesinden çıkarılma talepleri, Yarışma ile ilgili dalış merkezi
+        başvuruları ve Yarışma hakkındaki diğer tüm soru ve şikayetleriniz
+        için:
       </p>
-      <p>
-        <span class="icon mr-2">
-          <i class="fa-solid fa-envelope"></i>
-        </span>
-        <a href="mailto:info@dipnot.app">info@dipnot.app</a>
-      </p>
-      <p>Yarışma hakkındaki diğer tüm soru ve şikayetleriniz için:</p>
       <p>
         <span class="icon mr-2">
           <i class="fa-solid fa-envelope"></i>


### PR DESCRIPTION
Ports Nev's copy edits into the source file. They were made directly in `_site/yarisma-kosullari.html`, which is gitignored build output — the next `npm run build` would have discarded them.

## Your four edits, now in source

| | Before | After |
| --- | --- | --- |
| Page title | Yarışma Koşulları \| Dipnot App | **2026** Yarışma Koşulları \| Dipnot App |
| `h1` | Yarışma Koşulları | **2026** Yarışma Koşulları |
| Competition name | 2026 Yılın Dalış Merkezi | 2026 Yılın **En Sevilen** Dalış Merkezi |
| Madde 5 opt-out | info@dipnot.app | help@dipnot.app |

## Three follow-on fixes an in-`_site` edit can't reach

1. **`og:title` was left stale.** Editing `<title>` in built output only changes the one tag; in source both derive from the same frontmatter `title`, so social cards now match the page.
2. **Meta description** still said "2026 Yılın Dalış Merkezi" — renamed to match.
3. **Madde 7 and Madde 13 contradicted the edits.** The award certificate was still called "2026 Yılın Dalış Merkezi ödül belgesi", and Madde 13 still routed opt-out requests to `info@` while Madde 5 now says `help@` — the same request pointed at two different addresses. Madde 13 is now a single `help@` contact block.

**Worth a look:** #3 is the one judgement call. Your Madde 5 edit moved opt-outs to `help@`, so I aligned Madde 13 to match, which made its two blocks redundant and they're now merged into one. If you meant to keep `info@` as the dive-centre-facing address and only change something else, this is the line to revert — say so and I'll flip both back.

Note the footer labels `info@` as "Genel iletişim" and `help@` as "Teknik destek", so an opt-out request arguably reads as general rather than technical. Both inboxes are monitored, so it's a routing preference, not a correctness issue.

## Checks

- `check:html` — pass
- `pa11y` — 5 errors, unchanged from baseline, all pre-existing footer issues (4× `.menu-label` contrast, 1× unlabelled newsletter input)
- Rebuilt output diffed against your edited file: identical apart from line wrapping and the three fixes above

`Son Güncelleme` left at 25 Temmuz 2026 — same-day copy correction to a page published today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)